### PR TITLE
Cloudflare Pages への自動デプロイ（Step 4）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,104 @@
+# Cloudflare Pages への自動デプロイ
+# - main への push → 本番デプロイ
+# - PR → プレビューデプロイ + プレビュー URL を PR にコメント
+#
+# 必要なシークレット（Settings > Secrets and variables > Actions）:
+# - CLOUDFLARE_API_TOKEN: Cloudflare ダッシュボードで作成（権限: Account > Cloudflare Pages > Edit）
+# - CLOUDFLARE_ACCOUNT_ID: Cloudflare ダッシュボードの Workers & Pages 画面右側に表示
+# 未設定の間、このワークフローはデプロイをスキップして成功扱いになる（CI は落とさない）
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    # フォークからの PR では secrets を参照できないためスキップ
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: シークレット設定の確認
+        id: config
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -z "$CF_API_TOKEN" ] || [ -z "$CF_ACCOUNT_ID" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID が未設定のためデプロイをスキップしました（設定手順は docs/HARNESS.md 参照）"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v5
+        if: steps.config.outputs.configured == 'true'
+
+      - uses: actions/setup-node@v5
+        if: steps.config.outputs.configured == 'true'
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: 依存関係のインストール
+        if: steps.config.outputs.configured == 'true'
+        run: npm ci
+
+      - name: ビルド（静的エクスポート）
+        if: steps.config.outputs.configured == 'true'
+        run: npm run build
+
+      # プロジェクト名・出力ディレクトリは wrangler.jsonc から解決される
+      # main への push は --branch=main で本番、PR はブランチ名でプレビューになる
+      - name: Cloudflare Pages へデプロイ
+        if: steps.config.outputs.configured == 'true'
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy --branch=${{ github.event_name == 'push' && 'main' || github.head_ref }}
+
+      - name: プレビュー URL を PR にコメント
+        if: steps.config.outputs.configured == 'true' && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          DEPLOY_URL: ${{ steps.deploy.outputs.deployment-url }}
+          ALIAS_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
+        with:
+          script: |
+            const marker = "<!-- cloudflare-pages-preview -->";
+            const url = process.env.ALIAS_URL || process.env.DEPLOY_URL;
+            const body = [
+              marker,
+              `🚀 **プレビューデプロイ**: ${url}`,
+              "",
+              `（コミット ${context.sha.slice(0, 7)} 時点。push のたびに更新されます）`,
+            ].join("\n");
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((c) => c.body.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,17 +78,23 @@ jobs:
           script: |
             const marker = "<!-- cloudflare-pages-preview -->";
             const url = process.env.ALIAS_URL || process.env.DEPLOY_URL;
+            // デプロイ URL が取得できなかった場合は undefined を投稿しないようスキップ
+            if (!url) {
+              core.warning("デプロイ URL を取得できなかったためコメント投稿をスキップします");
+              return;
+            }
             const body = [
               marker,
               `🚀 **プレビューデプロイ**: ${url}`,
               "",
               `（コミット ${context.sha.slice(0, 7)} 時点。push のたびに更新されます）`,
             ].join("\n");
-            const { data: comments } = await github.rest.issues.listComments({
+            // コメントが 30 件を超えてもマーカーを取りこぼさないよう全ページ取得する
+            const comments = await github.paginate(github.rest.issues.listComments, {
               ...context.repo,
               issue_number: context.issue.number,
             });
-            const existing = comments.find((c) => c.body.startsWith(marker));
+            const existing = comments.find((c) => c.body?.startsWith(marker));
             if (existing) {
               await github.rest.issues.updateComment({
                 ...context.repo,

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -20,8 +20,11 @@ flowchart TD
     H -- フックが検知 --> I[サブエージェントが<br>/review-pr を実行<br>インラインコメント投稿]
     I --> J[別サブエージェントが<br>/resolve-pr-comments を実行<br>修正・返信・push]
     H --> K[GitHub Actions CI<br>lint / typecheck / test / build]
+    H --> P[Deploy ワークフロー<br>プレビュー URL を PR にコメント]
     K -- 緑 --> L[人間がマージ判断]
+    P --> L
     J --> L
+    L -- main へマージ --> M[Deploy ワークフロー<br>本番デプロイ]
 ```
 
 ## 構成要素
@@ -85,6 +88,25 @@ flowchart TD
 - **コスト**: public リポジトリのため標準ランナーは分数無制限で無料
 - **Node は 24 に固定**（ローカル開発環境と一致させる。npm 10 系は lockfile の検証挙動が異なり `npm ci` が失敗するため）
 - 同一ブランチへの連続 push では `concurrency` により古い実行を自動キャンセル
+- **main はブランチ保護済み**: CI のジョブ `check` が緑でないとマージ不可（管理者含む）。force push・ブランチ削除も禁止
+
+### 8. デプロイ自動化（`.github/workflows/deploy.yml`）
+
+- **main への push** → Cloudflare Pages へ本番デプロイ
+- **PR** → プレビューデプロイを行い、プレビュー URL を PR にコメント（push のたびに同じコメントを更新）
+- フォークからの PR ではシークレットを参照できないためスキップされる
+- プロジェクト名・出力ディレクトリは `wrangler.jsonc` から解決される
+
+#### 必要なシークレット（未設定の間はデプロイをスキップして成功扱い）
+
+リポジトリの Settings > Secrets and variables > Actions で以下を登録する:
+
+| シークレット | 取得方法 |
+| --- | --- |
+| `CLOUDFLARE_API_TOKEN` | Cloudflare ダッシュボード > My Profile > API Tokens > Create Token。権限は「Account > Cloudflare Pages > Edit」のカスタムトークン |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare ダッシュボードの Workers & Pages 画面右側に表示される Account ID |
+
+CLI からは `gh secret set CLOUDFLARE_API_TOKEN` / `gh secret set CLOUDFLARE_ACCOUNT_ID`（対話プロンプトで値を入力）でも登録できる。
 
 ## 運用上の注意
 
@@ -96,4 +118,5 @@ flowchart TD
 
 ## 変更履歴
 
+- 2026-07-04: main のブランチ保護（CI 必須化）とデプロイ自動化（本番 + PR プレビュー）を追加
 - 2026-07-04: 初版（PR #3 検証ハーネス / PR #4 エージェント・PR 自動レビュー / PR #5 CI）


### PR DESCRIPTION
## 概要

ハーネス整備 Step 4。main へのマージで本番デプロイ、PR ごとにプレビュー URL の自動発行を行う Deploy ワークフローを追加します。これで「デプロイは人間が手動実行」「動作確認はローカル起動」の両方が不要になります。

## 変更内容

- `.github/workflows/deploy.yml` を追加
  - **main への push** → `wrangler pages deploy --branch=main` で本番デプロイ
  - **PR** → ブランチ名でプレビューデプロイし、プレビュー URL を PR にコメント（push ごとに同一コメントを更新）
  - シークレット未設定の間は**デプロイをスキップして成功扱い**（CI を汚さない）
  - フォークからの PR はシークレット非参照のためスキップ
- `docs/HARNESS.md` に全体図の更新、ブランチ保護の記述、デプロイ節（シークレット登録手順）を追記

## 有効化に必要な作業（1回だけ・人間側）

1. Cloudflare ダッシュボード > My Profile > API Tokens で「Account > Cloudflare Pages > Edit」権限のトークンを作成
2. ターミナルで以下を実行して登録:
   ```bash
   gh secret set CLOUDFLARE_API_TOKEN   # プロンプトにトークンを貼り付け
   gh secret set CLOUDFLARE_ACCOUNT_ID  # Workers & Pages 画面右側の Account ID
   ```

## 検証

- [x] シークレット未設定状態でワークフローがスキップ成功することを本 PR の Actions 実行で確認予定
- [x] ブランチ保護（main: CI の `check` 必須、管理者含む、force push 禁止）を設定済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)