### PR TITLE
Playwright E2E テストの導入（Step 2）+ GPS Ref タグ削除漏れの修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,31 @@ jobs:
 
       - name: ビルド（静的エクスポート）
         run: npm run build
+
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: 依存関係のインストール
+        run: npm ci
+
+      - name: Playwright ブラウザのインストール
+        run: npx playwright install --with-deps chromium
+
+      - name: E2E テスト（Playwright）
+        run: npm run e2e
+
+      - name: 失敗時にレポートをアップロード
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,9 @@ next-env.d.ts
 
 # Claude Code の個人設定（共有しない）
 .claude/settings.local.json
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/e2e/convert.spec.ts
+++ b/e2e/convert.spec.ts
@@ -12,9 +12,12 @@ test.describe("画像フォーマット変換", () => {
       timeout: 15_000,
     });
 
+    // 1 ファイル時は ZIP 化されず単一ファイルとしてダウンロードされる
     const [download] = await Promise.all([
       page.waitForEvent("download"),
-      page.getByRole("button", { name: "ダウンロード" }).click(),
+      page
+        .getByRole("button", { name: "Zipでダウンロード", exact: true })
+        .click(),
     ]);
 
     expect(download.suggestedFilename()).toBe("sample.jpeg");
@@ -33,9 +36,12 @@ test.describe("画像フォーマット変換", () => {
       timeout: 15_000,
     });
 
+    // 1 ファイル時は ZIP 化されず単一ファイルとしてダウンロードされる
     const [download] = await Promise.all([
       page.waitForEvent("download"),
-      page.getByRole("button", { name: "ダウンロード" }).click(),
+      page
+        .getByRole("button", { name: "Zipでダウンロード", exact: true })
+        .click(),
     ]);
 
     expect(download.suggestedFilename()).toBe("sample.webp");

--- a/e2e/convert.spec.ts
+++ b/e2e/convert.spec.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { expect, test } from "@playwright/test";
+import { magicNumber, pngFile } from "./helpers/fixtures";
+
+test.describe("画像フォーマット変換", () => {
+  test("PNG を JPEG に変換してダウンロードできる", async ({ page }) => {
+    await page.goto("/convert/");
+    await page.locator('input[type="file"]').setInputFiles(pngFile());
+
+    await page.getByRole("button", { name: "変換", exact: true }).click();
+    await expect(page.getByRole("heading", { name: /変換結果/ })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.getByRole("button", { name: "ダウンロード" }).click(),
+    ]);
+
+    expect(download.suggestedFilename()).toBe("sample.jpeg");
+    const buf = readFileSync(await download.path());
+    expect(magicNumber.isJpeg(buf)).toBe(true);
+  });
+
+  test("PNG を WebP に変換してダウンロードできる", async ({ page }) => {
+    await page.goto("/convert/");
+    await page.locator('input[type="file"]').setInputFiles(pngFile());
+
+    // ラジオの input は不可視のためラベルテキストをクリックする
+    await page.getByText("WebP", { exact: true }).click();
+    await page.getByRole("button", { name: "変換", exact: true }).click();
+    await expect(page.getByRole("heading", { name: /変換結果/ })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.getByRole("button", { name: "ダウンロード" }).click(),
+    ]);
+
+    expect(download.suggestedFilename()).toBe("sample.webp");
+    const buf = readFileSync(await download.path());
+    expect(magicNumber.isWebp(buf)).toBe(true);
+  });
+});

--- a/e2e/crop.spec.ts
+++ b/e2e/crop.spec.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { expect, test } from "@playwright/test";
+import { magicNumber, pngFile } from "./helpers/fixtures";
+
+test.describe("画像トリミング", () => {
+  test("画像をトリミングしてダウンロードできる", async ({ page }) => {
+    await page.goto("/crop/");
+    await page.locator('input[type="file"]').setInputFiles(pngFile());
+
+    // 画像読み込み後に初期トリミング領域（画像全体）が設定されるとボタンが有効になる
+    const cropButton = page.getByRole("button", {
+      name: "トリミング",
+      exact: true,
+    });
+    await expect(cropButton).toBeEnabled({ timeout: 15_000 });
+    await cropButton.click();
+
+    await expect(page.getByRole("heading", { name: /変換結果/ })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.getByRole("button", { name: "ダウンロード" }).click(),
+    ]);
+
+    // トリミング結果には _cropped サフィックスが付与される
+    expect(download.suggestedFilename()).toBe("sample_cropped.png");
+    const buf = readFileSync(await download.path());
+    expect(magicNumber.isPng(buf)).toBe(true);
+  });
+});

--- a/e2e/crop.spec.ts
+++ b/e2e/crop.spec.ts
@@ -19,9 +19,12 @@ test.describe("画像トリミング", () => {
       timeout: 15_000,
     });
 
+    // 1 ファイル時は ZIP 化されず単一ファイルとしてダウンロードされる
     const [download] = await Promise.all([
       page.waitForEvent("download"),
-      page.getByRole("button", { name: "ダウンロード" }).click(),
+      page
+        .getByRole("button", { name: "Zipでダウンロード", exact: true })
+        .click(),
     ]);
 
     // トリミング結果には _cropped サフィックスが付与される

--- a/e2e/helpers/fixtures.ts
+++ b/e2e/helpers/fixtures.ts
@@ -1,0 +1,75 @@
+import piexif from "piexifjs";
+
+/**
+ * E2E テスト用の画像フィクスチャ生成ヘルパー
+ * Playwright の setInputFiles にはファイルパスの代わりに
+ * { name, mimeType, buffer } を渡せるため、バイナリをリポジトリに置かず実行時に生成する
+ */
+
+// 1x1 ピクセルの PNG
+const PNG_1PX_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+// 1x1 ピクセルの最小 JPEG（EXIF なし）
+const BASE_JPEG_BASE64 =
+  "/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3+iiigD//2Q==";
+
+/** setInputFiles に渡せる 1x1 PNG ファイル */
+export const pngFile = (name = "sample.png") => ({
+  name,
+  mimeType: "image/png",
+  buffer: Buffer.from(PNG_1PX_BASE64, "base64"),
+});
+
+/** GPS・カメラ情報入りの EXIF を埋め込んだ JPEG ファイル */
+export const jpegFileWithExif = (name = "with-exif.jpg") => {
+  const exifObj = {
+    "0th": {
+      [piexif.ImageIFD.Make]: "TestMake",
+      [piexif.ImageIFD.Model]: "TestModel",
+    },
+    Exif: {
+      [piexif.ExifIFD.DateTimeOriginal]: "2024:01:01 00:00:00",
+    },
+    GPS: {
+      [piexif.GPSIFD.GPSLatitudeRef]: "N",
+      [piexif.GPSIFD.GPSLatitude]: [
+        [35, 1],
+        [40, 1],
+        [0, 1],
+      ] as unknown as number[],
+      [piexif.GPSIFD.GPSLongitudeRef]: "E",
+      [piexif.GPSIFD.GPSLongitude]: [
+        [139, 1],
+        [45, 1],
+        [0, 1],
+      ] as unknown as number[],
+    },
+  };
+  const exifBytes = piexif.dump(exifObj);
+  const dataUrl = piexif.insert(
+    exifBytes,
+    `data:image/jpeg;base64,${BASE_JPEG_BASE64}`,
+  );
+  return {
+    name,
+    mimeType: "image/jpeg",
+    buffer: Buffer.from(dataUrl.split(",")[1], "base64"),
+  };
+};
+
+/** ダウンロードした JPEG バイナリから EXIF を読み出す */
+export const loadExifFromBuffer = (buf: Buffer) => {
+  return piexif.load(`data:image/jpeg;base64,${buf.toString("base64")}`);
+};
+
+/** バイナリの先頭がフォーマットのマジックナンバーと一致するか */
+export const magicNumber = {
+  isJpeg: (buf: Buffer) =>
+    buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff,
+  isPng: (buf: Buffer) =>
+    buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47,
+  isWebp: (buf: Buffer) =>
+    buf.subarray(0, 4).toString("ascii") === "RIFF" &&
+    buf.subarray(8, 12).toString("ascii") === "WEBP",
+};

--- a/e2e/helpers/fixtures.ts
+++ b/e2e/helpers/fixtures.ts
@@ -32,6 +32,8 @@ export const jpegFileWithExif = (name = "with-exif.jpg") => {
       [piexif.ExifIFD.DateTimeOriginal]: "2024:01:01 00:00:00",
     },
     GPS: {
+      // GPSVersionID はタグ ID が 0 のため、truthiness 判定による削除漏れの回帰検知に使う
+      [piexif.GPSIFD.GPSVersionID]: [2, 3, 0, 0] as unknown as number[],
       [piexif.GPSIFD.GPSLatitudeRef]: "N",
       [piexif.GPSIFD.GPSLatitude]: [
         [35, 1],

--- a/e2e/metadata.spec.ts
+++ b/e2e/metadata.spec.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { expect, test } from "@playwright/test";
+import {
+  jpegFileWithExif,
+  loadExifFromBuffer,
+  magicNumber,
+} from "./helpers/fixtures";
+
+test.describe("EXIF メタデータ管理", () => {
+  test("EXIF が表示され、リスクタグを削除した画像をダウンロードできる", async ({
+    page,
+  }) => {
+    await page.goto("/metadata/");
+    await page.locator('input[type="file"]').setInputFiles(jpegFileWithExif());
+
+    // EXIF 解析完了を待つ
+    await expect(
+      page.getByRole("heading", { name: /すべてのEXIFタグ/ }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // アップロードした画像の EXIF タグが表示されている
+    // （プライバシーリスク節と全タグ節の両方に出ることがあるため first() で確認）
+    await expect(page.getByText("Make", { exact: true }).first()).toBeVisible();
+    await expect(
+      page.getByText("GPSLatitude", { exact: true }).first(),
+    ).toBeVisible();
+
+    // リスクタグを選択して削除実行
+    await page.getByRole("button", { name: "リスクタグを選択" }).click();
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page
+        .getByRole("button", { name: "クリーニング済み画像をダウンロード" })
+        .click(),
+    ]);
+
+    expect(download.suggestedFilename()).toBe("cleaned_with-exif.jpg");
+    const buf = readFileSync(await download.path());
+    expect(magicNumber.isJpeg(buf)).toBe(true);
+
+    // GPS 情報が実際に削除されている（バイナリを piexifjs で解析して検証）
+    const exif = loadExifFromBuffer(buf);
+    expect(Object.keys(exif.GPS ?? {})).toHaveLength(0);
+  });
+});

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("スモークテスト", () => {
+  test("トップページが表示され、各ツールへのナビゲーションがある", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    // 同名の見出しがヘッダー(h2)にもあるため、ページ本文の h1 に限定する
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "Client-Side Image Converter",
+      }),
+    ).toBeVisible();
+
+    // ヘッダーナビゲーション（ページ本文の CTA リンクと同名のため nav にスコープする）
+    const nav = page.getByRole("navigation");
+    await expect(nav.getByRole("link", { name: "変換" })).toBeVisible();
+    await expect(nav.getByRole("link", { name: "トリミング" })).toBeVisible();
+    await expect(nav.getByRole("link", { name: "メタデータ" })).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
+        "@playwright/test": "^1.61.1",
         "@types/exif-js": "^2.3.1",
         "@types/jszip": "^3.4.0",
         "@types/node": "^20",
@@ -1765,6 +1766,23 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -4567,10 +4585,9 @@
       }
     },
     "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6440,6 +6457,38 @@
       "integrity": "sha512-0wVyH0cKohzBQ5Gi2V1BuxYpxWfxF3cSqfFXfPIpl5tl9XLS5z4ogqhUCD20AbHi0h9aJkqXNJnkVev6gwh2ag==",
       "license": "MIT"
     },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -7710,6 +7759,21 @@
         }
       }
     },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
@@ -8069,6 +8133,21 @@
         "@cloudflare/workers-types": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wrangler/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
     "deploy": "npm run build && wrangler pages deploy out",
     "preview": "wrangler pages dev out"
   },
@@ -45,6 +47,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
+    "@playwright/test": "^1.61.1",
     "@types/exif-js": "^2.3.1",
     "@types/jszip": "^3.4.0",
     "@types/node": "^20",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
+  use: {
+    // 他プロジェクトの dev サーバー（3000 番）と衝突しないよう E2E 専用ポートを使う
+    baseURL: "http://localhost:3100",
+    // アプリは navigator.language で表示言語を決めるため ja に固定する
+    locale: "ja-JP",
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: "npm run dev -- --port 3100",
+    url: "http://localhost:3100",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/src/utils/__tests__/metadataManager.test.ts
+++ b/src/utils/__tests__/metadataManager.test.ts
@@ -114,6 +114,21 @@ describe("removeMetadataFromImage", () => {
     expect(exif["0th"]?.[piexif.ImageIFD.Model]).toBe("TestModel");
   });
 
+  it("GPSLatitudeRef / GPSLongitudeRef など Ref 系の GPS タグも個別削除できる", async () => {
+    const file = createJpegFileWithExif();
+    const result = await removeMetadataFromImage(file, [
+      "GPSLatitude",
+      "GPSLatitudeRef",
+      "GPSLongitude",
+      "GPSLongitudeRef",
+    ]);
+    const exif = await loadExifFromFile(result);
+
+    // Ref 系タグの取りこぼしがないこと（過去に GPSLatitudeRef 等が残存するバグがあった）
+    expect(Object.keys(exif.GPS ?? {})).toHaveLength(0);
+    expect(exif["0th"]?.[piexif.ImageIFD.Make]).toBe("TestMake");
+  });
+
   it("削除対象タグが空の場合は元のファイルをそのまま返す", async () => {
     const file = createJpegFileWithExif();
     const result = await removeMetadataFromImage(file, []);

--- a/src/utils/__tests__/metadataManager.test.ts
+++ b/src/utils/__tests__/metadataManager.test.ts
@@ -18,6 +18,8 @@ const createJpegFileWithExif = (): File => {
       [piexif.ExifIFD.DateTimeOriginal]: "2024:01:01 00:00:00",
     },
     GPS: {
+      // GPSVersionID はタグ ID が 0 のため、truthiness 判定による削除漏れの回帰検知に使う
+      [piexif.GPSIFD.GPSVersionID]: [2, 3, 0, 0] as unknown as number[],
       [piexif.GPSIFD.GPSLatitudeRef]: "N",
       [piexif.GPSIFD.GPSLatitude]: [
         [35, 1],
@@ -117,6 +119,7 @@ describe("removeMetadataFromImage", () => {
   it("GPSLatitudeRef / GPSLongitudeRef など Ref 系の GPS タグも個別削除できる", async () => {
     const file = createJpegFileWithExif();
     const result = await removeMetadataFromImage(file, [
+      "GPSVersionID",
       "GPSLatitude",
       "GPSLatitudeRef",
       "GPSLongitude",
@@ -125,6 +128,7 @@ describe("removeMetadataFromImage", () => {
     const exif = await loadExifFromFile(result);
 
     // Ref 系タグの取りこぼしがないこと（過去に GPSLatitudeRef 等が残存するバグがあった）
+    // GPSVersionID（タグ ID = 0）も削除され、GPS IFD が完全に空になること
     expect(Object.keys(exif.GPS ?? {})).toHaveLength(0);
     expect(exif["0th"]?.[piexif.ImageIFD.Make]).toBe("TestMake");
   });

--- a/src/utils/metadataManager.ts
+++ b/src/utils/metadataManager.ts
@@ -94,7 +94,12 @@ const removeTagsFromExifObj = (
     }
 
     // GPSタグの個別削除
-    if (tagName.startsWith("GPS") && gpsTagMapping[tagName] && exifObj.GPS) {
+    // GPSVersionID はタグ ID が 0（falsy）のため、undefined チェックで判定する
+    if (
+      tagName.startsWith("GPS") &&
+      gpsTagMapping[tagName] !== undefined &&
+      exifObj.GPS
+    ) {
       delete exifObj.GPS[gpsTagMapping[tagName]];
     }
   }

--- a/src/utils/metadataManager.ts
+++ b/src/utils/metadataManager.ts
@@ -76,15 +76,9 @@ const removeTagsFromExifObj = (
     LensSerialNumber: { ifd: "Exif", tag: piexif.ExifIFD.LensSerialNumber },
   };
 
-  // GPS関連のタグを処理
-  const gpsTagMapping: Record<string, number> = {
-    GPSLatitude: piexif.GPSIFD.GPSLatitude,
-    GPSLongitude: piexif.GPSIFD.GPSLongitude,
-    GPSAltitude: piexif.GPSIFD.GPSAltitude,
-    GPSImgDirection: piexif.GPSIFD.GPSImgDirection,
-    GPSDateStamp: piexif.GPSIFD.GPSDateStamp,
-    GPSTimeStamp: piexif.GPSIFD.GPSTimeStamp,
-  };
+  // GPS関連のタグは piexif.GPSIFD の定義（全 GPS タグ名 → タグ ID）を参照して削除する
+  // （個別マッピングだと GPSLatitudeRef / GPSLongitudeRef 等の Ref 系タグが漏れるため）
+  const gpsTagMapping = piexif.GPSIFD as unknown as Record<string, number>;
 
   for (const tagName of tagsToRemove) {
     // GPS全体を削除する場合


### PR DESCRIPTION
## 概要

ハーネス整備 Step 2。実ブラウザ（Chromium）での E2E テストを導入し、「アップロード → 変換/トリミング/EXIF削除 → ダウンロード」という人間が手で行っていた動作確認をコード化しました。導入初回の実行で**本物のプライバシーバグを 1 件発見・修正**しています。

## E2E テスト（`e2e/`、計 5 件）

| テスト | 検証内容 |
| --- | --- |
| convert | PNG→JPEG / PNG→WebP 変換。ダウンロード物のマジックナンバー（FFD8FF / RIFF+WEBP)とファイル名を検証 |
| metadata | EXIF タグの表示 → リスクタグ削除 → ダウンロード物を piexifjs で解析し **GPS が実際に消えている**ことをバイナリレベルで検証 |
| crop | トリミング実行 → `_cropped` サフィックス付き PNG のダウンロード検証 |
| smoke | トップページ表示とナビゲーション |

- フィクスチャ（EXIF 入り JPEG 等)はバイナリをリポジトリに置かず、piexifjs で実行時生成
- dev サーバーは E2E 専用ポート 3100 で自動起動（他プロジェクトの 3000 番と衝突しない）
- 実行: `npm run e2e`（UI モード: `npm run e2e:ui`）

## 発見・修正したバグ 🐛

**GPS の Ref 系タグ（GPSLatitudeRef / GPSLongitudeRef）が削除されない**

`metadataManager.ts` の GPS タグマッピングが 6 タグのハードコードで、Ref 系が漏れていました。その結果「リスクタグを選択」で GPSLatitudeRef 等が選択されるのに、クリーニング後の画像に**緯度経度の方位情報が残存**していました（E2E がダウンロード物のバイナリ解析で検出）。

修正: `piexif.GPSIFD` の全タグ定義を参照する方式に変更。回帰テストをユニットテストに追加（52 件、全通過）。

## CI

- `e2e` ジョブを追加（Chromium のみ、失敗時は playwright-report をアーティファクト保存、約 2〜3 分）
- lockfile はゼロから再生成し `npm ci` の通過を確認済み（macOS 差分更新問題の再発対策）

## 検証

- [x] E2E 5 件すべてローカルで通過
- [x] lint / typecheck / ユニットテスト 52 件通過
- [x] `npm ci` クリーンインストール通過

## 補足

- `e2e` ジョブを main のマージ必須チェックに加えるのは、本 PR マージ後に実施予定（先に必須化すると本 PR 以前の PR がマージできなくなるため）
- docs/HARNESS.md への E2E 記述追加は #7 とのコンフリクト回避のため、両 PR マージ後に行います

🤖 Generated with [Claude Code](https://claude.com/claude-code)