### PR TITLE
AVIF 出力対応（@jsquash/avif WASM エンコーダー）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ npm run preview
 - `src/components/` - 再利用可能な React コンポーネント
 - `src/utils/` - コアユーティリティクラス
   - `imageConverter.ts` - 画像フォーマット変換処理
+  - `avifEncoder.ts` - AVIF エンコード処理（`@jsquash/avif` の WASM を動的 import）
   - `imageCropper.ts` - 画像トリミング処理
   - `metadataManager.ts` - EXIF データ管理
   - `__tests__/` - 単体テスト
@@ -90,14 +91,15 @@ npm run preview
 ※ vitest 用のエイリアスは `vitest.config.ts` にも定義されている。エイリアスを追加する場合は両方を更新すること。
 
 ### コア機能
-1. **画像フォーマット変換** - JPEG、PNG、WebP 形式間の変換（品質制御付き）
+1. **画像フォーマット変換** - JPEG、PNG、WebP、AVIF 形式への変換（品質制御付き。AVIF は出力のみ対応）
 2. **画像トリミング** - プレビュー付きのビジュアルトリミングインターフェース
 3. **EXIF メタデータ管理** - EXIF データの表示、編集、選択的削除
 4. **バッチ処理** - 複数画像の一括処理
-5. **プライバシーファースト** - Canvas API を使用したクライアントサイドでの全処理
+5. **プライバシーファースト** - Canvas API / WASM を使用したクライアントサイドでの全処理
 
 ### 重要なパターン
-- すべての画像処理はクライアントサイド操作のために Canvas API を使用
+- 画像処理はクライアントサイド操作のために Canvas API を使用
+- AVIF エンコードのみ Canvas の `toBlob("image/avif")` が全ブラウザ未実装のため、`@jsquash/avif`（WASM）を動的 import で使用（AVIF 変換実行時のみロードされ、初期バンドルに影響しない。処理はブラウザ内で完結）
 - EXIF データ処理は保存に `piexifjs`、読み取りに `exif-js` を使用
 - テーマ切り替え（ライト/ダーク）は CSS カスタムプロパティで処理
 - 言語設定は localStorage に保存
@@ -109,7 +111,7 @@ npm run preview
 - テストファイルはテスト対象と同じディレクトリの `__tests__/` に `<対象ファイル名>.test.ts` として配置する
 - `src/utils/` のロジックを追加・変更した場合は、対応する単体テストを追加・更新すること
 - EXIF 処理のテストは piexifjs でフィクスチャ（EXIF 入り JPEG）を生成して実データで検証する（`metadataManager.test.ts` 参照）
-- Canvas API に依存する処理（描画・変換）は happy-dom では動作しないため、単体テストの対象外とする（純粋ロジック部分を切り出してテストする）
+- Canvas API や WASM に依存する処理（描画・変換・エンコード）は happy-dom では動作しないため、単体テストの対象外とする（純粋ロジック部分を切り出してテストする）
 - Canvas 依存の動作は Playwright E2E（`e2e/`）で実ブラウザ検証する。ダウンロード物はマジックナンバーや piexifjs のバイナリ解析で中身まで検証する（`e2e/metadata.spec.ts` 参照）
 - E2E のフィクスチャはバイナリを置かず `e2e/helpers/fixtures.ts` で実行時生成する
 - E2E は本番同等の静的エクスポート（`npm run build` + `serve out`、ポート 3100）に対して実行される。ローカルで高速に回したい場合は `npm run dev -- --port 3100` を別途起動しておけば `reuseExistingServer` により再利用される（CI では常に build + 静的配信）
@@ -178,5 +180,6 @@ npm run preview
 - 実装前に既存のコンポーネントの再利用を検討する
 
 ## 最近の更新
+- 画像フォーマット変換の出力形式に AVIF を追加（`@jsquash/avif` の WASM エンコーダーを動的 import で使用）
 - 開発ハーネスを整備（詳細は `docs/HARNESS.md`）: vitest による単体テスト、Claude Code フック（自動フォーマット / 完了時チェック）、サブエージェント（planner / docs-sync / reviewer）、PR 自動レビューフロー、GitHub Actions CI
 - `feat/exif-editor` ブランチで EXIF メタデータの選択的削除機能を実装

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -135,7 +135,7 @@ CLI からは `gh secret set CLOUDFLARE_API_TOKEN` / `gh secret set CLOUDFLARE_A
 ### 9. E2E テスト（`e2e/` + Playwright）
 
 - 実ブラウザ（Chromium）で「アップロード → 変換/トリミング/EXIF 削除 → ダウンロード」を検証する
-- **ダウンロード物の中身まで検証する**: マジックナンバー（JPEG/PNG/WebP）、piexifjs によるバイナリ解析（GPS 削除の確認）
+- **ダウンロード物の中身まで検証する**: マジックナンバー（JPEG/PNG/WebP/AVIF）、piexifjs によるバイナリ解析（GPS 削除の確認）
 - フィクスチャ（EXIF 入り JPEG 等）はバイナリを置かず `e2e/helpers/fixtures.ts` で実行時生成
 - webServer は `npm run build && npx serve out -l 3100` により**本番同等の静的エクスポート（`out/`）を配信**して検証する。ポートは E2E 専用の 3100（他プロジェクトの 3000 番と衝突しない）
 - ローカルで高速に回したい場合は `npm run dev -- --port 3100` を別途起動しておけば `reuseExistingServer` によりそちらが再利用される（CI では常に build + 静的配信）
@@ -152,6 +152,7 @@ CLI からは `gh secret set CLOUDFLARE_API_TOKEN` / `gh secret set CLOUDFLARE_A
 
 ## 変更履歴
 
+- 2026-07-06: AVIF 出力対応（Issue #29）に伴い、E2E のマジックナンバー検証対象に AVIF を追加
 - 2026-07-05: `/start-issue` コマンドを追加（Issue 起点でブランチ作成から PR 作成・自動レビューフローまでハーネス全体を自走させる入口）
 - 2026-07-05: Dependabot による依存の週次自動更新、permissions による危険操作のガード（deny / ask）を追加。E2E の webServer を本番同等の静的配信（build + serve）に変更
 - 2026-07-05: docs-sync エージェントを追加（レビュー前に関連ドキュメントの同期を自動化）

--- a/e2e/convert.spec.ts
+++ b/e2e/convert.spec.ts
@@ -48,4 +48,29 @@ test.describe("画像フォーマット変換", () => {
     const buf = readFileSync(await download.path());
     expect(magicNumber.isWebp(buf)).toBe(true);
   });
+
+  test("PNG を AVIF に変換してダウンロードできる", async ({ page }) => {
+    await page.goto("/convert/");
+    await page.locator('input[type="file"]').setInputFiles(pngFile());
+
+    // ラジオの input は不可視のためラベルテキストをクリックする
+    await page.getByText("AVIF", { exact: true }).click();
+    await page.getByRole("button", { name: "変換", exact: true }).click();
+    // WASM エンコーダーの初回ロードがあるためタイムアウトを長めにとる
+    await expect(page.getByRole("heading", { name: /変換結果/ })).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // 1 ファイル時は ZIP 化されず単一ファイルとしてダウンロードされる
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page
+        .getByRole("button", { name: "Zipでダウンロード", exact: true })
+        .click(),
+    ]);
+
+    expect(download.suggestedFilename()).toBe("sample.avif");
+    const buf = readFileSync(await download.path());
+    expect(magicNumber.isAvif(buf)).toBe(true);
+  });
 });

--- a/e2e/helpers/fixtures.ts
+++ b/e2e/helpers/fixtures.ts
@@ -74,4 +74,6 @@ export const magicNumber = {
   isWebp: (buf: Buffer) =>
     buf.subarray(0, 4).toString("ascii") === "RIFF" &&
     buf.subarray(8, 12).toString("ascii") === "WEBP",
+  // ISOBMFF コンテナの ftyp ボックス（オフセット 4-12 が "ftypavif"）
+  isAvif: (buf: Buffer) => buf.subarray(4, 12).toString("ascii") === "ftypavif",
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -595,6 +595,31 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -4839,7 +4864,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8962,7 +8986,6 @@
       "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@jsquash/avif": "^2.1.1",
         "exif-js": "^2.3.0",
         "i18next": "^25.10.9",
         "jszip": "^3.10.1",
@@ -592,31 +593,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1820,6 +1796,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jsquash/avif": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@jsquash/avif/-/avif-2.1.1.tgz",
+      "integrity": "sha512-LMRxd0fMgfCLtobDh0/sFYJMMiRJTNYSEEWvRDKXlAeZ08t3gI5V+1thIT0XjXJ+SVG7Zug9B0XPyx0Ti5VRNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "wasm-feature-detect": "^1.2.11"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -4854,6 +4839,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8976,6 +8962,7 @@
       "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -9216,6 +9203,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "preview": "wrangler pages dev out"
   },
   "dependencies": {
+    "@jsquash/avif": "^2.1.1",
     "exif-js": "^2.3.0",
     "i18next": "^25.10.9",
     "jszip": "^3.10.1",

--- a/src/app/convert/components/ConversionSettings.tsx
+++ b/src/app/convert/components/ConversionSettings.tsx
@@ -4,10 +4,11 @@ import { useTranslation } from "react-i18next";
 import { Button } from "../../../components/Button";
 import { Input } from "../../../components/Input";
 import { RadioButtonGroup } from "../../../components/RadioButtonGroup";
+import type { ConversionFormat } from "../../../utils/imageConverter";
 import styles from "./ConversionSettings.module.css";
 
 export interface ConversionSettings {
-  targetFormat: "jpeg" | "png" | "webp";
+  targetFormat: ConversionFormat;
   quality: number;
   width?: number;
   height?: number;
@@ -58,12 +59,13 @@ export const ConversionSettings: React.FC<ConversionSettingsProps> = ({
     { label: "JPEG", value: "jpeg" },
     { label: "PNG", value: "png" },
     { label: "WebP", value: "webp" },
+    { label: "AVIF", value: "avif" },
   ];
 
   const handleFormatChange = (format: string) => {
     onSettingsChange({
       ...settings,
-      targetFormat: format as "jpeg" | "png" | "webp",
+      targetFormat: format as ConversionFormat,
     });
   };
 

--- a/src/app/convert/components/ConversionSettings.tsx
+++ b/src/app/convert/components/ConversionSettings.tsx
@@ -55,7 +55,8 @@ export const ConversionSettings: React.FC<ConversionSettingsProps> = ({
     setLocalHeight(settings.height?.toString() || "");
   }, [settings.height]);
 
-  const formatOptions = [
+  // value に型注釈を付け、選択肢と ConversionFormat の整合を型で担保する
+  const formatOptions: { label: string; value: ConversionFormat }[] = [
     { label: "JPEG", value: "jpeg" },
     { label: "PNG", value: "png" },
     { label: "WebP", value: "webp" },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -23,7 +23,7 @@
     "features": {
       "formatConversion": {
         "title": "Format Conversion",
-        "description": "Convert between image formats\nsuch as JPEG, PNG, WebP\nwhile adjusting quality and size.",
+        "description": "Convert between image formats\nsuch as JPEG, PNG, WebP, AVIF\nwhile adjusting quality and size.",
         "iconAlt": "Format conversion icon"
       },
       "imageCropping": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -23,7 +23,7 @@
     "features": {
       "formatConversion": {
         "title": "フォーマット変換",
-        "description": "JPEG、PNG、WebPなどの\n画像フォーマット間で\n品質･サイズを調整しながら\n変換できます。",
+        "description": "JPEG、PNG、WebP、AVIFなどの\n画像フォーマット間で\n品質･サイズを調整しながら\n変換できます。",
         "iconAlt": "フォーマット変換アイコン"
       },
       "imageCropping": {

--- a/src/utils/__tests__/avifEncoder.test.ts
+++ b/src/utils/__tests__/avifEncoder.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAvifQuality } from "../avifEncoder";
+
+// encodeCanvasToAvifBlob は Canvas / WASM 依存のため単体テスト対象外（E2E で検証する）
+
+describe("normalizeAvifQuality", () => {
+  it("範囲内の整数はそのまま返す", () => {
+    expect(normalizeAvifQuality(50)).toBe(50);
+    expect(normalizeAvifQuality(1)).toBe(1);
+    expect(normalizeAvifQuality(100)).toBe(100);
+  });
+
+  it("範囲外の値は 1-100 にクランプする", () => {
+    expect(normalizeAvifQuality(0)).toBe(1);
+    expect(normalizeAvifQuality(-10)).toBe(1);
+    expect(normalizeAvifQuality(101)).toBe(100);
+    expect(normalizeAvifQuality(1000)).toBe(100);
+  });
+
+  it("小数は整数に丸める", () => {
+    expect(normalizeAvifQuality(89.4)).toBe(89);
+    expect(normalizeAvifQuality(89.5)).toBe(90);
+  });
+
+  it("非有限値はデフォルト品質を返す", () => {
+    expect(normalizeAvifQuality(Number.NaN)).toBe(90);
+    expect(normalizeAvifQuality(Number.POSITIVE_INFINITY)).toBe(90);
+    expect(normalizeAvifQuality(Number.NEGATIVE_INFINITY)).toBe(90);
+  });
+});

--- a/src/utils/avifEncoder.ts
+++ b/src/utils/avifEncoder.ts
@@ -1,0 +1,42 @@
+/**
+ * AVIF エンコード処理
+ *
+ * Canvas の toBlob("image/avif") は全ブラウザ未実装（PNG にフォールバックする）ため、
+ * Squoosh 由来の WASM エンコーダー @jsquash/avif を使用する。
+ * WASM（約 1MB）は動的 import により AVIF 変換実行時のみロードされる。
+ */
+
+/** AVIF エンコードに渡す品質値のデフォルト（@jsquash/avif の quality は 0-100） */
+const DEFAULT_AVIF_QUALITY = 90;
+
+/**
+ * 品質値を @jsquash/avif が受け付ける 1-100 の整数に正規化する
+ */
+export const normalizeAvifQuality = (quality: number): number => {
+  if (!Number.isFinite(quality)) {
+    return DEFAULT_AVIF_QUALITY;
+  }
+  return Math.min(100, Math.max(1, Math.round(quality)));
+};
+
+/**
+ * Canvas の内容を AVIF 形式の Blob にエンコードする
+ */
+export const encodeCanvasToAvifBlob = async (
+  canvas: HTMLCanvasElement,
+  quality: number,
+): Promise<Blob> => {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    throw new Error("Canvas context を取得できませんでした");
+  }
+
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  // index.js 経由だと不要な decode 側も取り込まれるため encode モジュールを直接 import する
+  const { default: encode } = await import("@jsquash/avif/encode.js");
+  const buffer = await encode(imageData, {
+    quality: normalizeAvifQuality(quality),
+  });
+
+  return new Blob([buffer], { type: "image/avif" });
+};

--- a/src/utils/avifEncoder.ts
+++ b/src/utils/avifEncoder.ts
@@ -3,7 +3,7 @@
  *
  * Canvas の toBlob("image/avif") は全ブラウザ未実装（PNG にフォールバックする）ため、
  * Squoosh 由来の WASM エンコーダー @jsquash/avif を使用する。
- * WASM（約 1MB）は動的 import により AVIF 変換実行時のみロードされる。
+ * WASM（約 3.5MB）は動的 import により AVIF 変換実行時のみロードされる。
  */
 
 /** AVIF エンコードに渡す品質値のデフォルト（@jsquash/avif の quality は 0-100） */

--- a/src/utils/avifEncoder.ts
+++ b/src/utils/avifEncoder.ts
@@ -6,11 +6,14 @@
  * WASM（約 3.5MB）は動的 import により AVIF 変換実行時のみロードされる。
  */
 
-/** AVIF エンコードに渡す品質値のデフォルト（@jsquash/avif の quality は 0-100） */
+/** AVIF エンコードに渡す品質値のデフォルト */
 const DEFAULT_AVIF_QUALITY = 90;
 
 /**
- * 品質値を @jsquash/avif が受け付ける 1-100 の整数に正規化する
+ * 品質値を UI と同じ 1-100 の整数に正規化する
+ *
+ * @jsquash/avif 自体は 0-100 を受け付けるが、下限は UI 側のクランプ
+ * （ConversionSettings.tsx の 1-100）に合わせて 1 とする
  */
 export const normalizeAvifQuality = (quality: number): number => {
   if (!Number.isFinite(quality)) {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -25,7 +25,7 @@ export const IMAGE_CONSTANTS = {
 // サポートされる画像フォーマット
 export const SUPPORTED_IMAGE_FORMATS = {
   // 変換でサポートされる形式
-  CONVERSION_FORMATS: ["image/jpeg", "image/png", "image/webp"],
+  CONVERSION_FORMATS: ["image/jpeg", "image/png", "image/webp", "image/avif"],
 
   // アップロードでサポートされる形式
   UPLOAD_FORMATS: [
@@ -48,6 +48,7 @@ export const IMAGE_FORMATS = {
   JPEG: "jpeg",
   PNG: "png",
   WEBP: "webp",
+  AVIF: "avif",
 } as const;
 
 // MIME タイプマッピング
@@ -55,6 +56,7 @@ export const MIME_TYPE_MAPPING = {
   [IMAGE_FORMATS.JPEG]: "image/jpeg",
   [IMAGE_FORMATS.PNG]: "image/png",
   [IMAGE_FORMATS.WEBP]: "image/webp",
+  [IMAGE_FORMATS.AVIF]: "image/avif",
 } as const;
 
 // UI関連の定数

--- a/src/utils/imageConverter.ts
+++ b/src/utils/imageConverter.ts
@@ -1,8 +1,11 @@
 import piexif from "piexifjs";
+import { encodeCanvasToAvifBlob } from "./avifEncoder";
 import { dataUrlToBlob } from "./imageUtils";
 
+export type ConversionFormat = "jpeg" | "png" | "webp" | "avif";
+
 export interface ConversionOptions {
-  format: "jpeg" | "png" | "webp";
+  format: ConversionFormat;
   quality: number; // 0-100
   width?: number;
   height?: number;
@@ -165,6 +168,11 @@ export const convertImage = async (
           if (options.format === "png") {
             // PNG専用の品質制御
             convertToPngWithQuality(canvas, options.quality, handleBlob);
+          } else if (options.format === "avif") {
+            // AVIF は Canvas ネイティブ未対応のため WASM エンコーダーを使用
+            encodeCanvasToAvifBlob(canvas, options.quality)
+              .then(handleBlob)
+              .catch(reject);
           } else {
             // JPEG/WebP用の標準品質制御
             const quality = options.quality / 100;


### PR DESCRIPTION
## 概要

画像フォーマット変換の出力形式に AVIF を追加します。

Closes #29

## 実装方針の変更（Issue 前提の検証結果）

Issue 本文は「Chrome / Firefox では Canvas の `toBlob("image/avif")` がネイティブ対応」を前提としていましたが、実機検証の結果この前提は誤りと判明しました：

- Chrome 150 / Playwright Chromium 149 で `toBlob("image/avif")` / `toDataURL("image/avif")` / `OffscreenCanvas.convertToBlob({type:"image/avif"})` を実行 → すべて `image/png` にフォールバック
- MDN Browser Compat Data 上も `HTMLCanvasElement.toBlob` の type パラメータ対応は `jpeg` / `png` / `webp` のみ（AVIF のエントリ自体が存在しない）

このまま実装すると全ブラウザで選択肢が無効化され機能として成立しないため、**Squoosh（Google）由来の WASM エンコーダー `@jsquash/avif` を採用**しました：

- WASM（約 3.5MB）は動的 import により AVIF 変換実行時のみロード（初期バンドルへの影響なし。`/convert` の First Load JS は 188kB のまま）
- 全処理クライアントサイド完結の原則は維持（WASM はブラウザ内実行）
- 全モダンブラウザで動作するため、Issue 記載の feature detection / 選択肢の無効化は不要になり UI はむしろ単純化

※ #28（HEIC 入力）も WASM ライブラリ導入前提であり、プロジェクトの方向性と整合します。

## 変更内容

- `src/utils/avifEncoder.ts`（新規）: 品質正規化（`normalizeAvifQuality`）と AVIF エンコード（`encodeCanvasToAvifBlob`）
- `src/utils/imageConverter.ts`: `ConversionFormat` 型を導入し `avif` 分岐を追加
- `src/app/convert/components/ConversionSettings.tsx`: フォーマット選択に AVIF を追加（型は `ConversionFormat` を再利用し union の重複を解消）
- `src/utils/constants.ts`: `IMAGE_FORMATS` / `MIME_TYPE_MAPPING` / `CONVERSION_FORMATS` に avif を追加
- `src/utils/__tests__/avifEncoder.test.ts`（新規）: `normalizeAvifQuality` の単体テスト
- `e2e/convert.spec.ts` / `e2e/helpers/fixtures.ts`: PNG→AVIF 変換の E2E テスト（`ftypavif` マジックナンバー検証）
- `CLAUDE.md` / `docs/HARNESS.md`: docs-sync によるドキュメント同期

EXIF 保持オプションは既存の「JPEG 出力時のみ有効」ロジックがそのまま AVIF にも適用されるため追加変更なし（AVIF 選択時は disabled + 説明文表示）。

## 検証

- `npm run lint` / `npm run typecheck` / `npm run test`（56 件）: すべてパス
- `npm run build`: 成功。WASM は `out/_next/static/media/` に静的アセットとして出力
- `npm run e2e`: 6 件すべてパス（本番同等の静的エクスポート配信。新規 AVIF テスト含む）
- reviewer エージェントによる独立レビュー: 合格（指摘なし）

## 既知の許容事項

- build 時に「Circular dependency between chunks with runtime」警告が 2 件出ます（main では 0 件）。`@jsquash/avif` 内部のネストした動的 import（シングルスレッド版/マルチスレッド版の分岐）に由来し、ビルドは成功、実害はチャンク間の contenthash 最適化の低下のみのため許容しています
- 古い Safari（16.4 未満）では AVIF のデコード非対応のため変換結果のプレビューが表示されない可能性がありますが、変換・ダウンロード自体は動作するためスコープ外としています

🤖 Generated with [Claude Code](https://claude.com/claude-code)
