### PR TITLE
feat: 目標ファイルサイズを指定した圧縮 (Issue #30)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ npm run preview
 ※ vitest 用のエイリアスは `vitest.config.ts` にも定義されている。エイリアスを追加する場合は両方を更新すること。
 
 ### コア機能
-1. **画像フォーマット変換** - JPEG、PNG、WebP、AVIF 形式への変換（品質制御付き。AVIF は出力のみ対応）。HEIC/HEIF（iPhone 写真）と TIFF は変換ページのみ入力として受理（crop / metadata はブラウザがプレビュー描画できないため対象外）。変換に失敗したファイルは一覧で画面に通知される
+1. **画像フォーマット変換** - JPEG、PNG、WebP、AVIF 形式への変換（品質制御付き。AVIF は出力のみ対応）。目標ファイルサイズ (KB) を指定すると品質を二分探索して目標以下で最大品質の結果を出力する（JPEG / WebP のみ。達成不可時は最小サイズで出力し一覧に警告表示）。HEIC/HEIF（iPhone 写真）と TIFF は変換ページのみ入力として受理（crop / metadata はブラウザがプレビュー描画できないため対象外）。変換に失敗したファイルは一覧で画面に通知される
 2. **画像トリミング** - プレビュー付きのビジュアルトリミングインターフェース
 3. **EXIF メタデータ管理** - EXIF データの表示、編集、選択的削除
 4. **バッチ処理** - 複数画像の一括処理
@@ -187,6 +187,7 @@ npm run preview
 - 実装前に既存のコンポーネントの再利用を検討する
 
 ## 最近の更新
+- 変換ページに目標ファイルサイズ (KB) 指定を追加（Issue #30）。指定すると品質値を二分探索し目標サイズ以下で最大品質の結果を採用する（JPEG / WebP のみ。PNG は可逆・AVIF は WASM が低速なため対象外）。探索は Canvas 非依存の純粋関数 `searchQualityForTargetSize`（`imageConverter.ts`）に切り出して単体テスト、実サイズ検証は E2E で実施。達成不可時は最小サイズで出力し結果一覧に警告表示
 - `/start-issue` コマンドを git worktree 対応に変更。Issue ごとに `.claude/worktrees/issue-{番号}/`（gitignore 済み）へ worktree を作成して作業するため、複数 Issue の並列作業が可能に
 - 変換ページに TIFF 入力対応を追加（`utif2` による動的デコード、Issue #26）。crop / metadata の受理形式からブラウザで描画できない TIFF を除外し、変換失敗ファイルの一覧通知を追加
 - Next.js を 16 に更新（PR #45）。Turbopack 本番ビルドが無限ハングする上流バグの回避のため `build` スクリプトを `next build --webpack` に暫定変更（dev は Turbopack のまま。上流修正後に戻す）

--- a/e2e/convert.spec.ts
+++ b/e2e/convert.spec.ts
@@ -5,6 +5,7 @@ import {
   brokenImageFile,
   heicFile,
   magicNumber,
+  noisyBmpFile,
   pngFile,
   tiffFile,
 } from "./helpers/fixtures";
@@ -253,5 +254,98 @@ test.describe("画像フォーマット変換", () => {
     expect(download.suggestedFilename()).toBe("sample.webp");
     const buf = readFileSync(await download.path());
     expect(magicNumber.isWebp(buf)).toBe(true);
+  });
+
+  test("目標ファイルサイズを指定して JPEG を圧縮できる", async ({ page }) => {
+    await page.goto("/convert/");
+    // 圧縮しにくい高周波 BMP を使い、目標サイズ以下への圧縮を検証する
+    await page.locator('input[type="file"]').setInputFiles(noisyBmpFile());
+
+    const targetKB = 40;
+    await page
+      .getByLabel("目標サイズ (KB)", { exact: true })
+      .fill(String(targetKB));
+
+    await page.getByRole("button", { name: "変換", exact: true }).click();
+    await expect(page.getByRole("heading", { name: /変換結果/ })).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page
+        .getByRole("button", { name: "Zipでダウンロード", exact: true })
+        .click(),
+    ]);
+
+    expect(download.suggestedFilename()).toBe("noisy.jpeg");
+    const buf = readFileSync(await download.path());
+    expect(magicNumber.isJpeg(buf)).toBe(true);
+    // 出力が目標サイズ（40KB）以下に収まっている
+    expect(buf.length).toBeLessThanOrEqual(targetKB * 1024);
+  });
+
+  test("目標ファイルサイズを指定して WebP を圧縮できる", async ({ page }) => {
+    await page.goto("/convert/");
+    await page.locator('input[type="file"]').setInputFiles(noisyBmpFile());
+
+    // ラジオの input は不可視のためラベルテキストをクリックする
+    await page.getByText("WebP", { exact: true }).click();
+
+    const targetKB = 40;
+    await page
+      .getByLabel("目標サイズ (KB)", { exact: true })
+      .fill(String(targetKB));
+
+    await page.getByRole("button", { name: "変換", exact: true }).click();
+    await expect(page.getByRole("heading", { name: /変換結果/ })).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page
+        .getByRole("button", { name: "Zipでダウンロード", exact: true })
+        .click(),
+    ]);
+
+    expect(download.suggestedFilename()).toBe("noisy.webp");
+    const buf = readFileSync(await download.path());
+    expect(magicNumber.isWebp(buf)).toBe(true);
+    expect(buf.length).toBeLessThanOrEqual(targetKB * 1024);
+  });
+
+  test("目標ファイルサイズが達成できない場合は警告を表示しフォールバック出力する", async ({
+    page,
+  }) => {
+    await page.goto("/convert/");
+    await page.locator('input[type="file"]').setInputFiles(noisyBmpFile());
+
+    // 1KB は最低品質でも達成不可能なため、フォールバック（最小サイズ）で出力される
+    await page.getByLabel("目標サイズ (KB)", { exact: true }).fill("1");
+
+    await page.getByRole("button", { name: "変換", exact: true }).click();
+    await expect(page.getByRole("heading", { name: /変換結果/ })).toBeVisible({
+      timeout: 20_000,
+    });
+
+    // 達成不可の警告が表示される（Next.js のルートアナウンサーも role="alert" のため文言でフィルタ）
+    const warning = page
+      .getByRole("alert")
+      .filter({ hasText: "目標サイズまで圧縮できませんでした" });
+    await expect(warning).toBeVisible();
+
+    // フォールバックでも有効な JPEG がダウンロードできる（目標は超過している）
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page
+        .getByRole("button", { name: "Zipでダウンロード", exact: true })
+        .click(),
+    ]);
+
+    expect(download.suggestedFilename()).toBe("noisy.jpeg");
+    const buf = readFileSync(await download.path());
+    expect(magicNumber.isJpeg(buf)).toBe(true);
+    expect(buf.length).toBeGreaterThan(1 * 1024);
   });
 });

--- a/e2e/helpers/fixtures.ts
+++ b/e2e/helpers/fixtures.ts
@@ -61,6 +61,48 @@ export const bmpFile = (name = "sample.bmp") => ({
   buffer: Buffer.from(BMP_1PX_BASE64, "base64"),
 });
 
+/**
+ * 目標ファイルサイズ探索の検証用に、圧縮しにくい高周波パターンの 24bit BMP を実行時生成する。
+ * 乱数を使わず決定論的なハッシュでピクセルを塗るため、生成結果とエンコード後サイズが安定する
+ * （品質を下げると顕著にサイズが縮むので二分探索が意味を持つ大きさになる）。
+ */
+export const noisyBmpFile = (name = "noisy.bmp", width = 400, height = 400) => {
+  // 24bit BMP の各行は 4 バイト境界にパディングされる
+  const rowSize = Math.floor((24 * width + 31) / 32) * 4;
+  const pixelDataSize = rowSize * height;
+  const fileSize = 54 + pixelDataSize;
+  const buf = Buffer.alloc(fileSize);
+
+  // BMP ファイルヘッダー（14 バイト）
+  buf.write("BM", 0, "ascii");
+  buf.writeUInt32LE(fileSize, 2);
+  buf.writeUInt32LE(54, 10); // ピクセルデータ開始オフセット
+
+  // DIB ヘッダー（BITMAPINFOHEADER、40 バイト）
+  buf.writeUInt32LE(40, 14);
+  buf.writeInt32LE(width, 18);
+  buf.writeInt32LE(height, 22);
+  buf.writeUInt16LE(1, 26); // プレーン数
+  buf.writeUInt16LE(24, 28); // ビット深度（24bit）
+  buf.writeUInt32LE(0, 30); // BI_RGB（無圧縮）
+  buf.writeUInt32LE(pixelDataSize, 34);
+
+  // 決定論的ハッシュで各ピクセルを塗る（ノイズ状で JPEG/WebP が圧縮しにくい）
+  for (let y = 0; y < height; y++) {
+    const rowStart = 54 + y * rowSize;
+    for (let x = 0; x < width; x++) {
+      const h = (x * 374761393 + y * 668265263) >>> 0;
+      const n = (h ^ (h >>> 13)) >>> 0;
+      const p = rowStart + x * 3;
+      buf[p] = n & 0xff; // B
+      buf[p + 1] = (n >>> 8) & 0xff; // G
+      buf[p + 2] = (n >>> 16) & 0xff; // R
+    }
+  }
+
+  return { name, mimeType: "image/bmp", buffer: buf };
+};
+
 /** PNG を装った破損ファイル（デコード失敗時の通知表示の検証に使用） */
 export const brokenImageFile = (name = "broken.png") => ({
   name,

--- a/src/app/convert/components/ConversionSettings.tsx
+++ b/src/app/convert/components/ConversionSettings.tsx
@@ -14,6 +14,7 @@ export interface ConversionSettings {
   height?: number;
   maintainAspectRatio: boolean;
   preserveExif: boolean;
+  targetFileSizeKB?: number;
 }
 
 interface ConversionSettingsProps {
@@ -41,6 +42,9 @@ export const ConversionSettings: React.FC<ConversionSettingsProps> = ({
   const [localHeight, setLocalHeight] = useState(
     settings.height?.toString() || "",
   );
+  const [localTargetFileSize, setLocalTargetFileSize] = useState(
+    settings.targetFileSizeKB?.toString() || "",
+  );
 
   // 外部のsettingsが変更された時にローカル状態を同期
   useEffect(() => {
@@ -54,6 +58,19 @@ export const ConversionSettings: React.FC<ConversionSettingsProps> = ({
   useEffect(() => {
     setLocalHeight(settings.height?.toString() || "");
   }, [settings.height]);
+
+  useEffect(() => {
+    setLocalTargetFileSize(settings.targetFileSizeKB?.toString() || "");
+  }, [settings.targetFileSizeKB]);
+
+  // 目標ファイルサイズ指定は JPEG / WebP のみ対応（PNG は可逆・AVIF は WASM が低速なため）
+  const supportsTargetSize =
+    settings.targetFormat === "jpeg" || settings.targetFormat === "webp";
+  // 有効な目標サイズが入力されている場合は品質を自動調整するため、品質入力を無効化する
+  const targetSizeActive =
+    supportsTargetSize &&
+    settings.targetFileSizeKB !== undefined &&
+    settings.targetFileSizeKB > 0;
 
   // value に型注釈を付け、選択肢と ConversionFormat の整合を型で担保する
   const formatOptions: { label: string; value: ConversionFormat }[] = [
@@ -115,6 +132,20 @@ export const ConversionSettings: React.FC<ConversionSettingsProps> = ({
     [settings, onSettingsChange],
   );
 
+  const handleTargetFileSizeChange = useCallback(
+    (value: string) => {
+      setLocalTargetFileSize(value);
+      const numeric = Number.parseInt(value, 10);
+      // 正の整数のみ有効な目標サイズとして扱い、それ以外（空・0・NaN）は未指定にする
+      onSettingsChange({
+        ...settings,
+        targetFileSizeKB:
+          !Number.isNaN(numeric) && numeric > 0 ? numeric : undefined,
+      });
+    },
+    [settings, onSettingsChange],
+  );
+
   const handleAspectRatioToggle = () => {
     onSettingsChange({
       ...settings,
@@ -152,13 +183,35 @@ export const ConversionSettings: React.FC<ConversionSettingsProps> = ({
           onChange={handleQualityChange}
           placeholder="90"
           type="number"
+          disabled={targetSizeActive}
         />
       </div>
 
       <div className={styles.helpText}>
-        {settings.targetFormat === "png"
-          ? t("convert.pngQualityHelp")
-          : t("convert.qualityDescription")}
+        {targetSizeActive
+          ? t("convert.qualityDisabledByTargetSize")
+          : settings.targetFormat === "png"
+            ? t("convert.pngQualityHelp")
+            : t("convert.qualityDescription")}
+      </div>
+
+      <h3 className={styles.sectionTitle}>{t("convert.targetFileSize")}</h3>
+
+      <div className={styles.inputGroup}>
+        <Input
+          label={t("convert.targetFileSizeLabel")}
+          value={localTargetFileSize}
+          onChange={handleTargetFileSizeChange}
+          placeholder={t("convert.auto")}
+          type="number"
+          disabled={!supportsTargetSize}
+        />
+      </div>
+
+      <div className={styles.helpText}>
+        {supportsTargetSize
+          ? t("convert.targetFileSizeHelp")
+          : t("convert.targetFileSizeUnsupported")}
       </div>
 
       <h3 className={styles.sectionTitle}>{t("convert.imageSize")}</h3>

--- a/src/app/convert/page.tsx
+++ b/src/app/convert/page.tsx
@@ -79,6 +79,7 @@ export default function Home() {
           height: conversionSettings.height,
           maintainAspectRatio: conversionSettings.maintainAspectRatio,
           preserveExif: conversionSettings.preserveExif,
+          targetFileSizeKB: conversionSettings.targetFileSizeKB,
         },
         (current, total) => {
           setConversionProgress({ current, total });

--- a/src/components/Results.module.css
+++ b/src/components/Results.module.css
@@ -162,3 +162,10 @@
   font-weight: 500;
   color: #dc2626;
 }
+
+.targetWarningText {
+  font-size: 12px;
+  font-weight: 500;
+  color: #d97706;
+  margin-top: 4px;
+}

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -357,6 +357,12 @@ export const ConversionResults: React.FC<ConversionResultsProps> = ({
                             {Math.abs(compressionRatio)}%
                           </span>
                         </div>
+                        {/* 目標ファイルサイズに到達できなかった場合の警告（最小サイズで出力） */}
+                        {result.targetSizeAchieved === false && (
+                          <p className={styles.targetWarningText} role="alert">
+                            ⚠️ {t("results.targetSizeNotAchieved")}
+                          </p>
+                        )}
                       </div>
                     </div>
                   </div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -57,6 +57,11 @@
     "pngQualityExperimental": "Experimental PNG quality control is supported. Lower values result in smaller file sizes but may reduce image quality.",
     "pngQualityHelp": "PNG Quality: 95+=Standard PNG, 70-94=Medium compression, <70=High compression (quality loss)",
     "qualityDescription": "Quality: Lower values result in smaller file sizes but reduced image quality",
+    "qualityDisabledByTargetSize": "Quality is adjusted automatically because a target file size is set.",
+    "targetFileSize": "Target File Size (Optional)",
+    "targetFileSizeLabel": "Target Size (KB)",
+    "targetFileSizeHelp": "When set, quality is adjusted automatically to keep the output at or below the target size (JPEG / WebP only). Leave empty to use the quality setting above.",
+    "targetFileSizeUnsupported": "Target file size is only supported for JPEG / WebP.",
     "metadataSettings": "Metadata Settings",
     "preserveExif": "Preserve EXIF Information",
     "preserveExifHelp": "When checked, EXIF information (date taken, camera info, etc.) from the original image will be preserved in the converted image. Only available for JPEG format.",
@@ -168,7 +173,8 @@
     "viewDetails": "View details for {{name}}",
     "viewComparison": "Show before/after comparison for {{name}}",
     "processingError": "Processing error",
-    "downloadError": "Failed to download files."
+    "downloadError": "Failed to download files.",
+    "targetSizeNotAchieved": "Could not compress down to the target size (output at minimum size)"
   },
   "comparison": {
     "original": "Original",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -57,6 +57,11 @@
     "pngQualityExperimental": "PNG形式での品質制御を実験的にサポートしています。低い値ではファイルサイズが小さくなりますが、画質が劣化する場合があります。",
     "pngQualityHelp": "PNG品質: 95以上=標準PNG、70-94=中圧縮、70未満=高圧縮（画質劣化あり）",
     "qualityDescription": "品質: 低い値ほどファイルサイズが小さくなりますが、画質が劣化します",
+    "qualityDisabledByTargetSize": "目標ファイルサイズが指定されているため、品質は自動調整されます。",
+    "targetFileSize": "目標ファイルサイズ（オプション）",
+    "targetFileSizeLabel": "目標サイズ (KB)",
+    "targetFileSizeHelp": "指定すると、目標サイズ以下になるよう品質を自動調整します（JPEG / WebP のみ）。空欄の場合は上記の品質設定が使われます。",
+    "targetFileSizeUnsupported": "目標ファイルサイズの指定は JPEG / WebP でのみ対応しています。",
     "metadataSettings": "メタデータ設定",
     "preserveExif": "EXIF情報を保持",
     "preserveExifHelp": "チェックすると、元画像のEXIF情報（撮影日時、カメラ情報など）が変換後の画像に保持されます。JPEG形式でのみ有効です。",
@@ -167,7 +172,8 @@
     "viewDetails": "{{name}}の詳細を表示",
     "viewComparison": "{{name}}の変換前後比較を表示",
     "processingError": "処理エラー",
-    "downloadError": "ファイルのダウンロードに失敗しました。"
+    "downloadError": "ファイルのダウンロードに失敗しました。",
+    "targetSizeNotAchieved": "目標サイズまで圧縮できませんでした（最小サイズで出力）"
   },
   "comparison": {
     "original": "変換前",

--- a/src/utils/__tests__/imageConverter.test.ts
+++ b/src/utils/__tests__/imageConverter.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { calculateTargetSize, convertMultipleImages } from "../imageConverter";
+import {
+  calculateTargetSize,
+  convertMultipleImages,
+  searchQualityForTargetSize,
+} from "../imageConverter";
 
 // convertImage 本体は Canvas / Image / WASM 依存のため単体テスト対象外（E2E で検証する）
 
@@ -96,5 +100,85 @@ describe("convertMultipleImages", () => {
       [2, 2],
     ]);
     vi.restoreAllMocks();
+  });
+});
+
+describe("searchQualityForTargetSize", () => {
+  // 指定バイト数の Blob を生成する（ascii 文字列は 1 文字 1 バイトなので size が length と一致する）
+  const blobOfSize = (bytes: number): Blob => new Blob(["x".repeat(bytes)]);
+
+  // 品質に比例したサイズ（size = quality * 100）を返す単調増加エンコーダー
+  const linearEncoder = () => {
+    const qualities: number[] = [];
+    const encode = (quality: number): Promise<Blob> => {
+      qualities.push(quality);
+      return Promise.resolve(blobOfSize(quality * 100));
+    };
+    return { encode, qualities };
+  };
+
+  it("目標以下で最大品質となる Blob を返す", async () => {
+    const { encode } = linearEncoder();
+    // target 5000 バイト → 品質 50（5000 バイト）が目標以下の最大品質
+    const result = await searchQualityForTargetSize(encode, 5000);
+    expect(result.achieved).toBe(true);
+    expect(result.quality).toBe(50);
+    expect(result.blob.size).toBe(5000);
+    expect(result.blob.size).toBeLessThanOrEqual(5000);
+  });
+
+  it("目標が最大品質のサイズ以上なら最大品質を返す", async () => {
+    const { encode } = linearEncoder();
+    // 品質 100 でも 10000 バイトで、target 20000 は余裕で達成可能 → 最大品質 100
+    const result = await searchQualityForTargetSize(encode, 20000);
+    expect(result.achieved).toBe(true);
+    expect(result.quality).toBe(100);
+    expect(result.blob.size).toBe(10000);
+  });
+
+  it("最低品質でも目標を超える場合は最小サイズの結果をフォールバックとして返す", async () => {
+    const { encode } = linearEncoder();
+    // 品質 1 でも 100 バイトあり、target 50 は達成不可 → 最小サイズ（品質 1）を返す
+    const result = await searchQualityForTargetSize(encode, 50);
+    expect(result.achieved).toBe(false);
+    expect(result.quality).toBe(1);
+    expect(result.blob.size).toBe(100);
+  });
+
+  it("反復回数の上限を超えてエンコードしない", async () => {
+    const { encode, qualities } = linearEncoder();
+    const result = await searchQualityForTargetSize(encode, 5000, {
+      maxIterations: 2,
+    });
+    // 2 回だけエンコードして、その時点で見つかった目標以下の候補を返す
+    expect(qualities).toHaveLength(2);
+    expect(result.achieved).toBe(true);
+    expect(result.blob.size).toBeLessThanOrEqual(5000);
+  });
+
+  it("カスタムの品質範囲内でのみ探索する", async () => {
+    const { encode, qualities } = linearEncoder();
+    const result = await searchQualityForTargetSize(encode, 5000, {
+      minQuality: 10,
+      maxQuality: 20,
+    });
+    // 範囲内（10-20）は全て 5000 バイト以下なので最大の品質 20 を返す
+    expect(result.achieved).toBe(true);
+    expect(result.quality).toBe(20);
+    // 探索した品質はすべて指定範囲内
+    for (const q of qualities) {
+      expect(q).toBeGreaterThanOrEqual(10);
+      expect(q).toBeLessThanOrEqual(20);
+    }
+  });
+
+  it("単調性が崩れても達成時は必ず目標以下の Blob を返す", async () => {
+    // 品質とサイズが単調増加しないエンコーダー（低品質で大・高品質で小）
+    const encode = (quality: number): Promise<Blob> =>
+      Promise.resolve(blobOfSize(quality <= 30 ? 8000 : 1000));
+    const result = await searchQualityForTargetSize(encode, 2000);
+    // 達成した場合、返す Blob は必ず目標以下（誤って目標超過を採用しない）
+    expect(result.achieved).toBe(true);
+    expect(result.blob.size).toBeLessThanOrEqual(2000);
   });
 });

--- a/src/utils/__tests__/imageConverter.test.ts
+++ b/src/utils/__tests__/imageConverter.test.ts
@@ -156,6 +156,28 @@ describe("searchQualityForTargetSize", () => {
     expect(result.blob.size).toBeLessThanOrEqual(5000);
   });
 
+  it("maxIterations が 0 の場合は末尾ガードで minQuality を 1 回だけエンコードして返す", async () => {
+    // 探索ループが一度も回らず best/smallest がともに null になる防御的分岐を検証する
+    const { encode, qualities } = linearEncoder();
+    // 目標 5000 バイトなら minQuality(=1, 100 バイト) は達成可能
+    const achievedResult = await searchQualityForTargetSize(encode, 5000, {
+      maxIterations: 0,
+    });
+    // 末尾ガードで minQuality のみを 1 回エンコードする
+    expect(qualities).toEqual([1]);
+    expect(achievedResult.quality).toBe(1);
+    expect(achievedResult.blob.size).toBe(100);
+    expect(achievedResult.achieved).toBe(true);
+
+    // 目標 50 バイトなら minQuality(100 バイト) でも超過するため achieved は false
+    const { encode: encode2 } = linearEncoder();
+    const unachievedResult = await searchQualityForTargetSize(encode2, 50, {
+      maxIterations: 0,
+    });
+    expect(unachievedResult.quality).toBe(1);
+    expect(unachievedResult.achieved).toBe(false);
+  });
+
   it("カスタムの品質範囲内でのみ探索する", async () => {
     const { encode, qualities } = linearEncoder();
     const result = await searchQualityForTargetSize(encode, 5000, {

--- a/src/utils/imageConverter.ts
+++ b/src/utils/imageConverter.ts
@@ -303,12 +303,13 @@ export const convertImage = async (
           // 既知の制限: JPEG で preserveExif も有効な場合、探索は EXIF 挿入前のサイズに対して
           // 行われるため（EXIF は handleBlob 内で後挿入する）、最終物は EXIF 分だけ目標を
           // わずかに超えうる。preserveExif は既定 false かつ超過幅は小さいため許容する。
-          const shouldSearchTargetSize =
+          // if 条件に直接展開することで TS が targetFileSizeKB を number に絞り込む
+          // （別変数に切り出すと絞り込みが効かず型アサーションが必要になる）
+          if (
             options.targetFileSizeKB !== undefined &&
-            options.targetFileSizeKB > 0;
-
-          if (shouldSearchTargetSize) {
-            const targetSizeBytes = (options.targetFileSizeKB as number) * 1024;
+            options.targetFileSizeKB > 0
+          ) {
+            const targetSizeBytes = options.targetFileSizeKB * 1024;
             // Canvas.toBlob を品質可変の Promise 化エンコード関数として探索に注入する
             const encode = (quality: number): Promise<Blob> =>
               new Promise((resolveEncode, rejectEncode) => {

--- a/src/utils/imageConverter.ts
+++ b/src/utils/imageConverter.ts
@@ -300,6 +300,9 @@ export const convertImage = async (
           const mimeType = `image/${options.format}`;
 
           // 目標ファイルサイズが指定されていれば品質を二分探索する（JPEG/WebP のみ）
+          // 既知の制限: JPEG で preserveExif も有効な場合、探索は EXIF 挿入前のサイズに対して
+          // 行われるため（EXIF は handleBlob 内で後挿入する）、最終物は EXIF 分だけ目標を
+          // わずかに超えうる。preserveExif は既定 false かつ超過幅は小さいため許容する。
           const shouldSearchTargetSize =
             options.targetFileSizeKB !== undefined &&
             options.targetFileSizeKB > 0;

--- a/src/utils/imageConverter.ts
+++ b/src/utils/imageConverter.ts
@@ -14,6 +14,12 @@ export interface ConversionOptions {
   height?: number;
   maintainAspectRatio: boolean;
   preserveExif?: boolean;
+  /**
+   * 目標ファイルサイズ（KB）。指定すると品質値を二分探索し、目標サイズ以下で最大品質の結果を採用する。
+   * JPEG / WebP でのみ有効（PNG は可逆・AVIF は WASM エンコードが低速なため対象外）。
+   * 未指定または 0 以下の場合は quality をそのまま使う。
+   */
+  targetFileSizeKB?: number;
 }
 
 export interface ConversionResult {
@@ -24,7 +30,88 @@ export interface ConversionResult {
   filename: string;
   originalFilename: string;
   file: File;
+  /**
+   * 目標ファイルサイズ探索を行った場合の達成可否。
+   * 探索を行わなかった場合は undefined、達成できなかった場合（最小サイズで出力）は false。
+   */
+  targetSizeAchieved?: boolean;
 }
+
+export interface QualitySearchOptions {
+  minQuality?: number; // 既定 1
+  maxQuality?: number; // 既定 100
+  maxIterations?: number; // 既定 8（1-100 の整数範囲は ceil(log2(100))=7 で十分絞れる）
+}
+
+export interface QualitySearchResult {
+  blob: Blob;
+  quality: number;
+  achieved: boolean; // 目標サイズ以下を達成できたか
+}
+
+/**
+ * エンコード関数を注入し、目標ファイルサイズ以下で最大品質となる品質値を二分探索する純粋ロジック。
+ *
+ * Canvas / Image / WASM に非依存（`encode` を差し替えれば happy-dom でも単体テスト可能）。
+ * 「品質↑でサイズ↑」という近似単調性を前提とするが、破れても以下の性質により常に妥当な結果を返す:
+ * - 探索した品質のいずれかで目標以下になれば、その中で最大品質の Blob（目標以下）を必ず返す
+ * - どの品質でも目標を超える場合は、探索中に見つけた最小 Blob を `achieved: false` で返す（フォールバック）
+ *
+ * @param encode - 品質値（1-100）を受け取り Blob を返すエンコード関数
+ * @param targetSizeBytes - 目標ファイルサイズ（バイト）
+ * @param options - 探索範囲・反復回数の上書き
+ */
+export const searchQualityForTargetSize = async (
+  encode: (quality: number) => Promise<Blob>,
+  targetSizeBytes: number,
+  options?: QualitySearchOptions,
+): Promise<QualitySearchResult> => {
+  const minQuality = options?.minQuality ?? 1;
+  const maxQuality = options?.maxQuality ?? 100;
+  const maxIterations = options?.maxIterations ?? 8;
+
+  let lo = minQuality;
+  let hi = maxQuality;
+  // 目標以下で見つかった最大品質の候補
+  let best: QualitySearchResult | null = null;
+  // 全探索点のうち最小サイズの Blob（達成不可時のフォールバック）
+  let smallest: QualitySearchResult | null = null;
+
+  let iterations = 0;
+  while (lo <= hi && iterations < maxIterations) {
+    const mid = Math.floor((lo + hi) / 2);
+    const blob = await encode(mid);
+    iterations++;
+
+    if (smallest === null || blob.size < smallest.blob.size) {
+      smallest = { blob, quality: mid, achieved: false };
+    }
+
+    if (blob.size <= targetSizeBytes) {
+      // 目標達成: より高品質を狙って範囲を上へ
+      best = { blob, quality: mid, achieved: true };
+      lo = mid + 1;
+    } else {
+      // 目標超過: 品質を下げる
+      hi = mid - 1;
+    }
+  }
+
+  if (best) {
+    return best;
+  }
+  if (smallest) {
+    // どの品質でも目標を超えた: 最小サイズの結果を返す
+    return smallest;
+  }
+  // maxIterations <= 0 等で一度もエンコードしなかった場合のガード
+  const fallbackBlob = await encode(minQuality);
+  return {
+    blob: fallbackBlob,
+    quality: minQuality,
+    achieved: fallbackBlob.size <= targetSizeBytes,
+  };
+};
 
 /**
  * 変換に失敗したファイルの情報（ユーザーへの通知表示に使用する）
@@ -132,7 +219,11 @@ export const convertImage = async (
         ctx.drawImage(source, 0, 0, width, height);
 
         // 変換後の処理を共通化
-        const handleBlob = (blob: Blob | null) => {
+        // targetSizeAchieved は目標サイズ探索を行った場合のみ渡す（未指定時は undefined）
+        const handleBlob = (
+          blob: Blob | null,
+          targetSizeAchieved?: boolean,
+        ) => {
           if (!blob) {
             reject(
               new Error(
@@ -166,6 +257,7 @@ export const convertImage = async (
               filename,
               originalFilename: file.name,
               file: resultFile,
+              targetSizeAchieved,
             });
           };
 
@@ -205,10 +297,42 @@ export const convertImage = async (
             .catch(reject);
         } else {
           // JPEG/WebP用の標準品質制御
-          const quality = options.quality / 100;
           const mimeType = `image/${options.format}`;
 
-          canvas.toBlob(handleBlob, mimeType, quality);
+          // 目標ファイルサイズが指定されていれば品質を二分探索する（JPEG/WebP のみ）
+          const shouldSearchTargetSize =
+            options.targetFileSizeKB !== undefined &&
+            options.targetFileSizeKB > 0;
+
+          if (shouldSearchTargetSize) {
+            const targetSizeBytes = (options.targetFileSizeKB as number) * 1024;
+            // Canvas.toBlob を品質可変の Promise 化エンコード関数として探索に注入する
+            const encode = (quality: number): Promise<Blob> =>
+              new Promise((resolveEncode, rejectEncode) => {
+                canvas.toBlob(
+                  (blob) => {
+                    if (blob) {
+                      resolveEncode(blob);
+                    } else {
+                      rejectEncode(
+                        new Error(
+                          `${options.format.toUpperCase()}画像の変換に失敗しました`,
+                        ),
+                      );
+                    }
+                  },
+                  mimeType,
+                  quality / 100,
+                );
+              });
+
+            searchQualityForTargetSize(encode, targetSizeBytes)
+              .then((result) => handleBlob(result.blob, result.achieved))
+              .catch(reject);
+          } else {
+            const quality = options.quality / 100;
+            canvas.toBlob(handleBlob, mimeType, quality);
+          }
         }
       } catch (error) {
         reject(error);


### PR DESCRIPTION
## 概要

変換ページに「目標ファイルサイズ (KB)」オプションを追加しました（Issue #30）。「この画像を 500KB 以下にしたい」といったサイズ制限対応のニーズに応えます。

指定すると `canvas.toBlob` の品質値を二分探索し、**目標サイズ以下で最大品質**となる結果を採用します。

Closes #30

## 対応内容

- **探索ロジック**: `src/utils/imageConverter.ts` に純粋関数 `searchQualityForTargetSize` を追加。エンコード関数を注入する設計（`(quality) => Promise<Blob>`）で Canvas / WASM に非依存とし、単体テスト可能にしました。
- **対象フォーマット**: JPEG / WebP のみ。PNG は可逆で品質制御が効かないため、AVIF は WASM エンコードが低速なため対象外としました。
- **品質との関係**: 目標サイズを指定すると品質入力を無効化（品質は自動調整）。PNG / AVIF 選択時は目標サイズ入力を無効化し、その旨を表示します。
- **フォールバック**: 最低品質でも目標を達成できない場合は、探索中の最小サイズの結果を出力し、結果一覧に達成不可の警告を表示します。
- **単調性の破れへの安全性**: 「品質↑でサイズ↑」の近似が破れても、探索点で目標以下のものがあれば必ず目標以下を返し、なければ最小サイズを返すため、誤って目標超過を採用しません（コメントで前提を明記）。

## テスト

- **単体テスト** (`imageConverter.test.ts`): 達成可能 / 目標が最大以上 / 達成不可フォールバック / 反復回数上限 / カスタム品質範囲 / 単調性破れ時の安全性 の 6 ケースを追加。
- **E2E** (`convert.spec.ts`): JPEG・WebP の目標サイズ達成（ダウンロード物のバイト長で検証）、達成不可時のフォールバック＋警告表示を追加。フィクスチャは `noisyBmpFile`（決定論的な高周波 BMP を実行時生成）。

### 検証結果（ローカル）

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test` ✅（93 passed）
- `npm run e2e` ✅（18 passed、新規 3 件含む）

## 変更ファイル

| ファイル | 変更内容 |
| --- | --- |
| `src/utils/imageConverter.ts` | 探索ロジック・型追加、`processSource` の JPEG/WebP 分岐に探索を組込み |
| `src/utils/__tests__/imageConverter.test.ts` | 探索ロジックの単体テスト |
| `src/app/convert/components/ConversionSettings.tsx` | 目標サイズ入力・相互無効化 |
| `src/app/convert/page.tsx` | options 受け渡し |
| `src/components/Results.tsx` / `Results.module.css` | 達成不可警告表示 |
| `src/i18n/locales/{ja,en}.json` | 翻訳キー |
| `e2e/helpers/fixtures.ts` / `e2e/convert.spec.ts` | E2E フィクスチャ・テスト |
| `CLAUDE.md` | コア機能・最近の更新に追記 |

## 既知の制限

JPEG で `preserveExif` も有効な場合、探索は EXIF 挿入前のサイズに対して行われるため（EXIF は後挿入）、最終物が EXIF 分だけ目標をわずかに超えることがあります。`preserveExif` は既定 false かつ超過幅は小さいため許容しています（コード内にコメント明記）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
