### PR TITLE
feat: ページ別 SEO メタデータの整備 (Issue #27)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ npm run preview
   - `tiffDecoder.ts` - TIFF デコード処理（`utif2` の純 JS デコーダー、動的 import）
   - `imageCropper.ts` - 画像トリミング処理
   - `metadataManager.ts` - EXIF データ管理
+  - `pageMetadata.ts` - ページ別 SEO メタデータ（title / description / OGP / Twitter / canonical）を組み立てる純粋関数 `buildPageMetadata` とサイト定数（`SITE_NAME` / `SITE_URL` / `SITE_LOCALE`）
   - `__tests__/` - 単体テスト
 - `src/i18n/` - 国際化設定
 - `src/types/` - 外部ライブラリの型定義（piexifjs / exif-js / heic-decode）
@@ -111,6 +112,7 @@ npm run preview
 - テーマ切り替え（ライト/ダーク）は CSS カスタムプロパティで処理
 - 言語設定は localStorage に保存
 - ファイルダウンロードはバッチ操作に `JSZip` を使用
+- ページ別の SEO メタデータ（title / description / OGP / Twitter card / canonical）は `pageMetadata.ts` の `buildPageMetadata` で組み立て、各ルートの `layout.tsx`（`"use client"` を持たないサーバーコンポーネント）から export する（ページ本体が client component で metadata を直接 export できないための構成）。root の `layout.tsx` が `metadataBase`・title テンプレート（`%s | Client-Side Image Converter`）・共通 description・OGP / Twitter 既定値を集約し、トップページ `/` はこの既定値を使う。メタデータは i18next 非経由の静的 HTML なので主言語は日本語（`lang="ja"` / i18n 既定 `lng: "ja"` に合わせる。ロケール JSON の変更は不要）。専用 OG 画像アセットが無いため Twitter card は `summary`（画像追加時に `summary_large_image` へ切り替える想定）
 
 ## テスト方針
 
@@ -187,6 +189,7 @@ npm run preview
 - 実装前に既存のコンポーネントの再利用を検討する
 
 ## 最近の更新
+- 各ページ（`/`, `/convert`, `/crop`, `/metadata`）に固有の SEO メタデータ（title / description / OGP / Twitter card / canonical）を付与（Issue #27）。`pageMetadata.ts` の純粋関数 `buildPageMetadata` で組み立て、各ルートの `layout.tsx`（サーバーコンポーネント層）から export する。root の `layout.tsx` に `metadataBase`・title テンプレート・共通 description・OGP / Twitter 既定値を集約。主言語は日本語で静的 HTML に出力されるため i18n（ロケール JSON）は非経由。単体テストは `pageMetadata.test.ts`、実 HTML 出力の検証は `e2e/seo-metadata.spec.ts` で実施
 - 変換ページに目標ファイルサイズ (KB) 指定を追加（Issue #30）。指定すると品質値を二分探索し目標サイズ以下で最大品質の結果を採用する（JPEG / WebP のみ。PNG は可逆・AVIF は WASM が低速なため対象外）。探索は Canvas 非依存の純粋関数 `searchQualityForTargetSize`（`imageConverter.ts`）に切り出して単体テスト、実サイズ検証は E2E で実施。達成不可時は最小サイズで出力し結果一覧に警告表示
 - `/start-issue` コマンドを git worktree 対応に変更。Issue ごとに `.claude/worktrees/issue-{番号}/`（gitignore 済み）へ worktree を作成して作業するため、複数 Issue の並列作業が可能に
 - 変換ページに TIFF 入力対応を追加（`utif2` による動的デコード、Issue #26）。crop / metadata の受理形式からブラウザで描画できない TIFF を除外し、変換失敗ファイルの一覧通知を追加

--- a/e2e/seo-metadata.spec.ts
+++ b/e2e/seo-metadata.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test";
+
+// 各ページ固有の SEO メタデータ（title / meta description）が静的エクスポートに
+// 正しく出力されていることを検証する。title は root layout の template で
+// "<ページ名> | Client-Side Image Converter" 形式に装飾される。
+const PAGES = [
+  {
+    name: "トップ",
+    path: "/",
+    title:
+      "Client-Side Image Converter | ブラウザ内で完結する画像変換・トリミングツール",
+    descriptionContains: "プライバシー重視の無料ツール",
+  },
+  {
+    name: "変換",
+    path: "/convert/",
+    title: "画像フォーマット変換 | Client-Side Image Converter",
+    descriptionContains: "JPEG・PNG・WebP・AVIF 形式へブラウザ内で画像を変換",
+  },
+  {
+    name: "トリミング",
+    path: "/crop/",
+    title: "画像トリミング | Client-Side Image Converter",
+    descriptionContains: "好きなサイズにトリミング",
+  },
+  {
+    name: "メタデータ",
+    path: "/metadata/",
+    title: "画像メタデータ・プライバシー管理 | Client-Side Image Converter",
+    descriptionContains: "EXIF メタデータ",
+  },
+] as const;
+
+test.describe("ページ別 SEO メタデータ", () => {
+  for (const p of PAGES) {
+    test(`${p.name}ページが固有の title / description を持つ`, async ({
+      page,
+    }) => {
+      await page.goto(p.path);
+
+      await expect(page).toHaveTitle(p.title);
+
+      const description = await page
+        .locator('head > meta[name="description"]')
+        .getAttribute("content");
+      expect(description).toContain(p.descriptionContains);
+    });
+  }
+
+  test("各ページの title が互いに異なる", async ({ page }) => {
+    const titles = new Set<string>();
+    for (const p of PAGES) {
+      await page.goto(p.path);
+      titles.add(await page.title());
+    }
+    expect(titles.size).toBe(PAGES.length);
+  });
+});

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,6 +1,10 @@
+// 本番 URL の単一の source of truth は site.config.json（canonical を出力する
+// src/utils/pageMetadata.ts と共有し、sitemap.xml と canonical の URL 不整合を防ぐ）。
+const { siteUrl } = require("./site.config.json");
+
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
-  siteUrl: "https://image-converter.suemura.app",
+  siteUrl,
   generateRobotsTxt: true,
   generateIndexSitemap: false,
   outDir: "./out",

--- a/site.config.json
+++ b/site.config.json
@@ -1,0 +1,3 @@
+{
+  "siteUrl": "https://image-converter.suemura.app"
+}

--- a/src/app/convert/layout.tsx
+++ b/src/app/convert/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { buildPageMetadata } from "../../utils/pageMetadata";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "画像フォーマット変換",
+  description:
+    "JPEG・PNG・WebP・AVIF 形式へブラウザ内で画像を変換。品質や目標ファイルサイズを指定でき、HEIC / TIFF の読み込みや複数画像の一括変換にも対応します。",
+  path: "/convert/",
+});
+
+// ページ本体は "use client" のため、metadata 定義用のサーバーコンポーネント層として children を返すだけの layout を置く。
+export default function ConvertLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/src/app/crop/layout.tsx
+++ b/src/app/crop/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { buildPageMetadata } from "../../utils/pageMetadata";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "画像トリミング",
+  description:
+    "プレビューを見ながら画像を好きなサイズにトリミング。処理はすべてブラウザ内で完結し、画像はサーバーに送信されません。",
+  path: "/crop/",
+});
+
+// ページ本体は "use client" のため、metadata 定義用のサーバーコンポーネント層として children を返すだけの layout を置く。
+export default function CropLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,6 +33,10 @@ export const metadata: Metadata = {
     template: `%s | ${SITE_NAME}`,
   },
   description: HOME_DESCRIPTION,
+  alternates: {
+    // サブページと同様にトップページにも canonical を付与して統一する
+    canonical: "/",
+  },
   openGraph: {
     type: "website",
     siteName: SITE_NAME,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,12 +23,15 @@ const notoSans = Noto_Sans({
 // 各ルートの layout.tsx が固有の title / description で上書きする。
 const HOME_DESCRIPTION =
   "JPEG・PNG・WebP・AVIF などの画像フォーマット変換、トリミング、EXIF メタデータ削除をすべてブラウザ内で実行。画像をサーバーに送信しないプライバシー重視の無料ツールです。";
+// トップページのタイトル。title.default / openGraph.title / twitter.title で共通利用し、
+// og:title には title.template（"%s | サイト名"）が効かないため直値をそろえて drift を防ぐ。
+const HOME_TITLE = `${SITE_NAME} | ブラウザ内で完結する画像変換・トリミングツール`;
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: {
     // トップページに適用される既定タイトル
-    default: `${SITE_NAME} | ブラウザ内で完結する画像変換・トリミングツール`,
+    default: HOME_TITLE,
     // 各ルートの title を "<ページ名> | サイト名" 形式に装飾する
     template: `%s | ${SITE_NAME}`,
   },
@@ -42,13 +45,13 @@ export const metadata: Metadata = {
     siteName: SITE_NAME,
     locale: SITE_LOCALE,
     url: "/",
-    title: `${SITE_NAME} | ブラウザ内で完結する画像変換・トリミングツール`,
+    title: HOME_TITLE,
     description: HOME_DESCRIPTION,
   },
   twitter: {
     // 専用の OG 画像アセットが無いため summary カードを使う（buildPageMetadata と同方針）
     card: "summary",
-    title: `${SITE_NAME} | ブラウザ内で完結する画像変換・トリミングツール`,
+    title: HOME_TITLE,
     description: HOME_DESCRIPTION,
   },
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Manrope, Noto_Sans } from "next/font/google";
 import { I18nProvider } from "../components/I18nProvider";
 import { ThemeProvider } from "../contexts/ThemeContext";
+import { SITE_LOCALE, SITE_NAME, SITE_URL } from "../utils/pageMetadata";
 import "./globals.css";
 
 const manrope = Manrope({
@@ -18,9 +19,34 @@ const notoSans = Noto_Sans({
   display: "swap",
 });
 
+// トップページ（"/"）のメタデータ兼サイト全体の既定値。
+// 各ルートの layout.tsx が固有の title / description で上書きする。
+const HOME_DESCRIPTION =
+  "JPEG・PNG・WebP・AVIF などの画像フォーマット変換、トリミング、EXIF メタデータ削除をすべてブラウザ内で実行。画像をサーバーに送信しないプライバシー重視の無料ツールです。";
+
 export const metadata: Metadata = {
-  title: "Image Converter",
-  description: "Convert images to various formats",
+  metadataBase: new URL(SITE_URL),
+  title: {
+    // トップページに適用される既定タイトル
+    default: `${SITE_NAME} | ブラウザ内で完結する画像変換・トリミングツール`,
+    // 各ルートの title を "<ページ名> | サイト名" 形式に装飾する
+    template: `%s | ${SITE_NAME}`,
+  },
+  description: HOME_DESCRIPTION,
+  openGraph: {
+    type: "website",
+    siteName: SITE_NAME,
+    locale: SITE_LOCALE,
+    url: "/",
+    title: `${SITE_NAME} | ブラウザ内で完結する画像変換・トリミングツール`,
+    description: HOME_DESCRIPTION,
+  },
+  twitter: {
+    // 専用の OG 画像アセットが無いため summary カードを使う（buildPageMetadata と同方針）
+    card: "summary",
+    title: `${SITE_NAME} | ブラウザ内で完結する画像変換・トリミングツール`,
+    description: HOME_DESCRIPTION,
+  },
 };
 
 export default function RootLayout({

--- a/src/app/metadata/layout.tsx
+++ b/src/app/metadata/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { buildPageMetadata } from "../../utils/pageMetadata";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "画像メタデータ・プライバシー管理",
+  description:
+    "画像の EXIF メタデータ（撮影日時・位置情報・カメラ情報など）を確認し、プライバシーに関わる情報を削除。JPEG は選択的削除、その他の形式は全削除に対応し、すべてブラウザ内で完結します。",
+  path: "/metadata/",
+});
+
+// ページ本体は "use client" のため、metadata 定義用のサーバーコンポーネント層として children を返すだけの layout を置く。
+export default function MetadataLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/src/utils/__tests__/pageMetadata.test.ts
+++ b/src/utils/__tests__/pageMetadata.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { buildPageMetadata, SITE_NAME } from "../pageMetadata";
+
+describe("buildPageMetadata", () => {
+  const input = {
+    title: "画像フォーマット変換",
+    description: "テスト用の説明文",
+    path: "/convert/",
+  };
+
+  it("title と description をそのまま設定する", () => {
+    const meta = buildPageMetadata(input);
+    expect(meta.title).toBe(input.title);
+    expect(meta.description).toBe(input.description);
+  });
+
+  it("canonical にルート絶対パスを設定する", () => {
+    const meta = buildPageMetadata(input);
+    expect(meta.alternates?.canonical).toBe("/convert/");
+  });
+
+  it("OGP に website タイプ・サイト名・ロケール・URL・サイト名付きタイトルを設定する", () => {
+    const meta = buildPageMetadata(input);
+    const expectedTitle = `${input.title} | ${SITE_NAME}`;
+    // openGraph / twitter は Metadata 型上でユニオンになるため、
+    // 個別のプロパティアクセスを避けて toMatchObject でまとめて検証する
+    expect(meta.openGraph).toMatchObject({
+      type: "website",
+      siteName: SITE_NAME,
+      locale: "ja_JP",
+      url: "/convert/",
+      title: expectedTitle,
+      description: input.description,
+    });
+  });
+
+  it("Twitter カードは summary でサイト名付きタイトルを使う", () => {
+    const meta = buildPageMetadata(input);
+    const expectedTitle = `${input.title} | ${SITE_NAME}`;
+    expect(meta.twitter).toMatchObject({
+      card: "summary",
+      title: expectedTitle,
+      description: input.description,
+    });
+  });
+});

--- a/src/utils/pageMetadata.ts
+++ b/src/utils/pageMetadata.ts
@@ -1,8 +1,11 @@
 import type { Metadata } from "next";
+// 本番 URL の単一の source of truth。JSON なので CJS の next-sitemap.config.js も
+// require で同じ値を参照でき、canonical（本ファイル由来）と sitemap.xml の URL が食い違わない。
+import siteConfig from "../../site.config.json";
 
 // サイト全体で共有する定数（root layout と各ルートの layout.tsx で使用）
 export const SITE_NAME = "Client-Side Image Converter";
-export const SITE_URL = "https://image-converter.suemura.app";
+export const SITE_URL = siteConfig.siteUrl;
 
 // メタデータの主言語は日本語とする（html lang="ja" / i18n の既定言語も ja のため）。
 // 静的エクスポートのため言語別 URL は存在しない。

--- a/src/utils/pageMetadata.ts
+++ b/src/utils/pageMetadata.ts
@@ -1,0 +1,50 @@
+import type { Metadata } from "next";
+
+// サイト全体で共有する定数（root layout と各ルートの layout.tsx で使用）
+export const SITE_NAME = "Client-Side Image Converter";
+export const SITE_URL = "https://image-converter.suemura.app";
+
+// メタデータの主言語は日本語とする（html lang="ja" / i18n の既定言語も ja のため）。
+// 静的エクスポートのため言語別 URL は存在しない。
+export const SITE_LOCALE = "ja_JP";
+
+type PageMetadataInput = {
+  // ページ固有タイトル。root layout の title.template（"%s | サイト名"）で装飾される
+  title: string;
+  description: string;
+  // canonical / og:url に使うルート絶対パス（例: "/convert/"）。
+  // trailingSlash: true の静的エクスポートに合わせて末尾スラッシュ付きで渡す
+  path: string;
+};
+
+// 各ページ固有の metadata（title / description / OGP / Twitter / canonical）を組み立てる純粋関数。
+// og:title は title.template が適用されないため、ここでサイト名を明示的に付与して補完する。
+export function buildPageMetadata({
+  title,
+  description,
+  path,
+}: PageMetadataInput): Metadata {
+  const ogTitle = `${title} | ${SITE_NAME}`;
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: path,
+    },
+    openGraph: {
+      type: "website",
+      siteName: SITE_NAME,
+      locale: SITE_LOCALE,
+      url: path,
+      title: ogTitle,
+      description,
+    },
+    twitter: {
+      // 専用の OG 画像アセットが無いため、大画像カード（summary_large_image）ではなく
+      // 画像なしでも自然な summary カードを使う。画像追加時に切り替える
+      card: "summary",
+      title: ogTitle,
+      description,
+    },
+  };
+}


### PR DESCRIPTION
## 概要

各ページ（`/`, `/convert`, `/crop`, `/metadata`）に固有の SEO メタデータ（title / description / OGP / Twitter card / canonical）を付与しました。従来は `layout.tsx` の metadata が全ページ `"Image Converter"` 固定で、ページ別のメタデータが無く検索流入の観点で機会損失していました（Issue #27）。

Closes #27

## 実装方針

- ページ本体は全て `"use client"` のため `export const metadata` を直接持てない。そこで各ルートに **children を返すだけのサーバーコンポーネント `layout.tsx`** を追加し、そこからページ固有 metadata を export する構成にした。
- 共通ロジックは純粋関数 `buildPageMetadata({ title, description, path })`（`src/utils/pageMetadata.ts`）に切り出し、単体テスト可能にした。
- **openGraph の浅いマージ対策**: Next.js は子セグメントが `openGraph` を未定義だと親の値を丸ごと継承するため、OGP / Twitter をページごとにフル指定し、`og:title` は `title.template` が効かないのでサイト名を明示付与している。
- root `layout.tsx` に `metadataBase`・title テンプレート（`%s | Client-Side Image Converter`）・共通 description・OGP / Twitter 既定値・home の canonical を集約。トップページ `/` はこの既定値を使う。

## 方針判断

- **主言語は日本語**: `lang="ja"` / i18n 既定 `lng: "ja"` に合わせる。静的エクスポートのため言語別 URL は存在せず、metadata は i18next 非経由の静的 HTML なので**ロケール JSON（ja/en.json）の変更は不要**。
- **Twitter card は `summary`**: 専用の OG 画像アセットが無いため（`summary_large_image` は画像追加時に切り替える想定）。

## 変更ファイル

| ファイル | 操作 | 内容 |
| --- | --- | --- |
| `src/utils/pageMetadata.ts` | 新規 | サイト定数 + 純粋関数 `buildPageMetadata` |
| `src/app/layout.tsx` | 修正 | root 既定値（metadataBase / title template / OGP / Twitter / canonical） |
| `src/app/convert/layout.tsx` | 新規 | 変換ページの固有 metadata |
| `src/app/crop/layout.tsx` | 新規 | トリミングページの固有 metadata |
| `src/app/metadata/layout.tsx` | 新規 | メタデータページの固有 metadata |
| `src/utils/__tests__/pageMetadata.test.ts` | 新規 | `buildPageMetadata` 単体テスト |
| `e2e/seo-metadata.spec.ts` | 新規 | 各ページの title / description E2E 検証 |
| `CLAUDE.md` | 修正 | 構成の追記（docs-sync） |

## 検証

- `npm run lint` ✅ / `npm run typecheck` ✅ / `npm run test`（98 passed）✅ / `npm run build`（静的エクスポート成功、postbuild の next-sitemap も成功）✅
- 生成物 `out/*/index.html` の `<head>` に各ページ固有の `<title>` / `<meta name="description">` / `<meta property="og:title">` / `<link rel="canonical">` が出力されることを実物で確認。
- `e2e/seo-metadata.spec.ts` が実ブラウザ（静的配信）で 5 件 pass。

### 出力例

| ページ | `<title>` |
| --- | --- |
| `/` | `Client-Side Image Converter \| ブラウザ内で完結する画像変換・トリミングツール` |
| `/convert/` | `画像フォーマット変換 \| Client-Side Image Converter` |
| `/crop/` | `画像トリミング \| Client-Side Image Converter` |
| `/metadata/` | `画像メタデータ・プライバシー管理 \| Client-Side Image Converter` |

## スコープ外（フォローアップ候補）

- 専用ブランド OG 画像（1200x630）の作成。`metadataBase` は設定済みのため、追加時は相対パスで `og:image` を足し Twitter card を `summary_large_image` に切り替えるだけで済む。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
