### PR TITLE
refactor: 小粒のコード品質改善（メモ化・型キャスト集約・二重 revoke 整理）

### DIFF
--- a/src/app/convert/page.tsx
+++ b/src/app/convert/page.tsx
@@ -57,14 +57,14 @@ export default function Home() {
     total: 0,
   });
 
-  const handleFilesSelected = (files: File[]) => {
+  const handleFilesSelected = useCallback((files: File[]) => {
     setSelectedFiles(files);
     // RAW ファイルが 1 件もなくなったら現像パラメータをリセットする
     // （個別削除後の再投入で前回の調整値が意図せず適用されるのを防ぐ）
     if (!files.some(isRawFile)) {
       setRawDevelopParams(DEFAULT_RAW_DEVELOP_PARAMS);
     }
-  };
+  }, []);
 
   // 他ツールからのハンドオフ（処理結果の引き継ぎ）を mount 時に取り込む
   const { notice: handoffNotice, clearNotice: clearHandoffNotice } =
@@ -73,7 +73,7 @@ export default function Home() {
       handleFilesSelected,
     );
 
-  const handleClearFiles = () => {
+  const handleClearFiles = useCallback(() => {
     setSelectedFiles([]);
     // ファイルを選び直す際は前回の失敗通知も不要になるためリセットする
     setConversionFailures([]);
@@ -81,11 +81,14 @@ export default function Home() {
     setRawDevelopParams(DEFAULT_RAW_DEVELOP_PARAMS);
     setPageErrorKey(null);
     clearHandoffNotice();
-  };
+  }, [clearHandoffNotice]);
 
-  const handleSettingsChange = (settings: ConversionSettingsType) => {
-    setConversionSettings(settings);
-  };
+  const handleSettingsChange = useCallback(
+    (settings: ConversionSettingsType) => {
+      setConversionSettings(settings);
+    },
+    [],
+  );
 
   const handleConvert = useCallback(async () => {
     if (selectedFiles.length === 0) {

--- a/src/app/crop/page.tsx
+++ b/src/app/crop/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "../../components/Button";
 import { ErrorNotice } from "../../components/ErrorNotice";
@@ -45,6 +45,12 @@ export default function CropPage() {
     handleNext: handleNextImage,
   } = useImageNavigation(files.length);
   const [previewUrl, setPreviewUrl] = useState<string>("");
+  // 最新の previewUrl を ref に保持し、アンマウント時クリーンアップが
+  // previewUrl の変化ごとに再生成・再実行されないようにする
+  const previewUrlRef = useRef(previewUrl);
+  useEffect(() => {
+    previewUrlRef.current = previewUrl;
+  }, [previewUrl]);
   const [isProcessing, setIsProcessing] = useState(false);
   const [progressCurrent, setProgressCurrent] = useState(0);
   const [progressTotal, setProgressTotal] = useState(0);
@@ -130,14 +136,16 @@ export default function CropPage() {
     };
   }, [files, currentPreviewIndex, rotation, flipHorizontal, flipVertical]);
 
-  // アンマウント時にプレビューURLをクリーンアップ
+  // アンマウント時にプレビューURLをクリーンアップ。
+  // 差し替え時の解放は生成 effect（setPreviewUrl の更新関数）と handleClearFiles が
+  // 担うため、ここでは previewUrl の変化ごとに再実行せず ref 経由で最新値のみ解放する
   useEffect(() => {
     return () => {
-      if (previewUrl) {
-        URL.revokeObjectURL(previewUrl);
+      if (previewUrlRef.current) {
+        URL.revokeObjectURL(previewUrlRef.current);
       }
     };
-  }, [previewUrl]);
+  }, []);
 
   const resetCropSettings = useCallback(() => {
     areaStore.reset();

--- a/src/app/metadata/page.tsx
+++ b/src/app/metadata/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "../../components/Button";
 import { ErrorNotice } from "../../components/ErrorNotice";
@@ -36,6 +36,12 @@ export default function MetadataPage() {
   const [imageUrls, setImageUrls] = useState<Map<string, string>>(new Map());
   // ダウンロード失敗の通知（次の実行開始でクリアする）
   const [downloadError, setDownloadError] = useState(false);
+  // 最新の imageUrls を ref に保持し、URL 解放処理が imageUrls へ依存せずに
+  // 済むようにする（ハンドラ・アンマウント時クリーンアップの不要な再生成を防ぐ）
+  const imageUrlsRef = useRef(imageUrls);
+  useEffect(() => {
+    imageUrlsRef.current = imageUrls;
+  }, [imageUrls]);
 
   const {
     analysis,
@@ -55,11 +61,15 @@ export default function MetadataPage() {
     removeSelectedMetadata,
   } = useMetadataManager();
 
-  // GPS 処理モードの選択肢（削除 / 市区町村レベルに丸める）
-  const gpsModeOptions = [
-    { label: t("metadata.gpsMode.remove"), value: "remove" },
-    { label: t("metadata.gpsMode.round"), value: "round" },
-  ];
+  // GPS 処理モードの選択肢（削除 / 市区町村レベルに丸める）。
+  // ラベルは翻訳に依存するため t の変化時のみ再生成する
+  const gpsModeOptions = useMemo(
+    () => [
+      { label: t("metadata.gpsMode.remove"), value: "remove" },
+      { label: t("metadata.gpsMode.round"), value: "round" },
+    ],
+    [t],
+  );
 
   // 解析結果に GPS 関連タグが含まれるか（GPS モード UI の表示判定に使う）
   const hasGpsTags = analysis
@@ -75,8 +85,8 @@ export default function MetadataPage() {
       const imageFiles = files.filter(isImageFile);
       setSelectedFiles(imageFiles);
 
-      // 既存のURLをクリーンアップ
-      for (const url of imageUrls.values()) {
+      // 既存のURLをクリーンアップ（最新値は ref から参照し imageUrls への依存を断つ）
+      for (const url of imageUrlsRef.current.values()) {
         URL.revokeObjectURL(url);
       }
 
@@ -93,7 +103,7 @@ export default function MetadataPage() {
         await analyzeFiles(imageFiles);
       }
     },
-    [analyzeFiles, imageUrls],
+    [analyzeFiles],
   );
 
   // 他ツールからのハンドオフ（処理結果の引き継ぎ）を mount 時に取り込む
@@ -104,13 +114,13 @@ export default function MetadataPage() {
 
   const handleClearFiles = useCallback(() => {
     setSelectedFiles([]);
-    // URLをクリーンアップ
-    for (const url of imageUrls.values()) {
+    // URLをクリーンアップ（最新値は ref から参照し imageUrls への依存を断つ）
+    for (const url of imageUrlsRef.current.values()) {
       URL.revokeObjectURL(url);
     }
     setImageUrls(new Map());
     clearHandoffNotice();
-  }, [imageUrls, clearHandoffNotice]);
+  }, [clearHandoffNotice]);
 
   const handleImageClick = useCallback((file: File) => {
     setSelectedFileForModal(file);
@@ -161,14 +171,16 @@ export default function MetadataPage() {
     }
   }, [analysis, selectedTags, removeSelectedMetadata]);
 
-  // クリーンアップ
+  // アンマウント時に残存 URL を解放する。個々の差し替え時の解放は
+  // handleFilesSelected / handleClearFiles 側で行うため、ここでは
+  // imageUrls の変化ごとに再実行せず ref 経由で最新値のみを対象にする
   useEffect(() => {
     return () => {
-      for (const url of imageUrls.values()) {
+      for (const url of imageUrlsRef.current.values()) {
         URL.revokeObjectURL(url);
       }
     };
-  }, [imageUrls]);
+  }, []);
 
   // プライバシーリスクの表示
   const getPrivacyRiskBadge = useCallback(

--- a/src/types/piexifjs.d.ts
+++ b/src/types/piexifjs.d.ts
@@ -95,6 +95,9 @@ declare module "piexifjs" {
   }
 
   interface GPSIFD {
+    // GPS タグ名（文字列）からタグ ID を引く用途（metadataManager の GPS 一括削除）。
+    // 全 GPS タグ ID は number のため、名前引きを型安全に許可する索引シグネチャを持たせる
+    [tagName: string]: number;
     GPSVersionID: number;
     GPSLatitudeRef: number;
     GPSLatitude: number;

--- a/src/utils/imageConverter.ts
+++ b/src/utils/imageConverter.ts
@@ -245,12 +245,11 @@ export const convertImage = async (
     // 例外は外側 Promise の reject へ接続し、unhandled rejection を防ぐ
     reader.onload = async (e) => {
       try {
+        // FileReader の結果は EXIF 読み取りと Image ソースの両方で使うため一度だけキャストする
+        const dataUrl = e.target?.result as string;
         let exifTiff: Uint8Array | null = null;
         if (shouldPreserveExif) {
-          exifTiff = await readExifTiffFromDataUrl(
-            e.target?.result as string,
-            file.type,
-          );
+          exifTiff = await readExifTiffFromDataUrl(dataUrl, file.type);
         }
 
         const img = new Image();
@@ -262,7 +261,7 @@ export const convertImage = async (
           reject(new Error("画像の読み込みに失敗しました"));
         };
 
-        img.src = e.target?.result as string;
+        img.src = dataUrl;
       } catch (error) {
         reject(error);
       }

--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -10,64 +10,38 @@ import { isRawFile } from "./fileUtils";
  * @returns サムネイルのDataURL、またはnull
  */
 export const generateThumbnail = (file: File): Promise<string | null> => {
-  return new Promise((resolve) => {
-    // RAW はブラウザの Image でデコードできず onerror で null になるだけなので、
-    // 数十 MB のファイルを readAsDataURL で無駄にメモリ展開する前に即 null を返す
-    if (!file.type.startsWith("image/") || isRawFile(file)) {
-      resolve(null);
-      return;
-    }
+  // RAW はブラウザの Image でデコードできず onerror で null になるだけなので、
+  // 数十 MB のファイルを readAsDataURL で無駄にメモリ展開する前に即 null を返す
+  if (!file.type.startsWith("image/") || isRawFile(file)) {
+    return Promise.resolve(null);
+  }
 
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      const img = new Image();
-      img.onload = () => {
-        const canvas = document.createElement("canvas");
-        const ctx = canvas.getContext("2d");
+  // 読み込み・デコードは fileToImage に集約し、失敗（読み込み / デコード）は
+  // いずれも null にフォールバックする（従来の resolve(null) と同じ挙動）
+  return fileToImage(file)
+    .then((img) => {
+      const canvas = document.createElement("canvas");
+      const ctx = canvas.getContext("2d");
 
-        // サムネイルのサイズを設定（32x32）
-        const size = 32;
-        canvas.width = size;
-        canvas.height = size;
+      // サムネイルのサイズを設定（32x32）
+      const size = 32;
+      canvas.width = size;
+      canvas.height = size;
 
-        if (ctx) {
-          // 画像を正方形にトリミングして描画
-          const minDimension = Math.min(img.width, img.height);
-          const sx = (img.width - minDimension) / 2;
-          const sy = (img.height - minDimension) / 2;
+      if (!ctx) {
+        return null;
+      }
 
-          ctx.drawImage(
-            img,
-            sx,
-            sy,
-            minDimension,
-            minDimension,
-            0,
-            0,
-            size,
-            size,
-          );
+      // 画像を正方形にトリミングして描画
+      const minDimension = Math.min(img.width, img.height);
+      const sx = (img.width - minDimension) / 2;
+      const sy = (img.height - minDimension) / 2;
 
-          const thumbnailUrl = canvas.toDataURL("image/png");
-          resolve(thumbnailUrl);
-        } else {
-          resolve(null);
-        }
-      };
+      ctx.drawImage(img, sx, sy, minDimension, minDimension, 0, 0, size, size);
 
-      img.onerror = () => {
-        resolve(null);
-      };
-
-      img.src = e.target?.result as string;
-    };
-
-    reader.onerror = () => {
-      resolve(null);
-    };
-
-    reader.readAsDataURL(file);
-  });
+      return canvas.toDataURL("image/png");
+    })
+    .catch(() => null);
 };
 
 /**
@@ -105,19 +79,16 @@ export const fileToDataUrl = (file: File): Promise<string> => {
  * @param file - 変換するファイル
  * @returns HTMLImageElement
  */
-export const fileToImage = (file: File): Promise<HTMLImageElement> => {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      const img = new Image();
-      img.onload = () => resolve(img);
-      img.onerror = () => reject(new Error("Failed to load image"));
-      img.src = e.target?.result as string;
-    };
-    reader.onerror = () => reject(new Error("Failed to read file"));
-    reader.readAsDataURL(file);
-  });
-};
+export const fileToImage = (file: File): Promise<HTMLImageElement> =>
+  fileToDataUrl(file).then(
+    (dataUrl) =>
+      new Promise<HTMLImageElement>((resolve, reject) => {
+        const img = new Image();
+        img.onload = () => resolve(img);
+        img.onerror = () => reject(new Error("Failed to load image"));
+        img.src = dataUrl;
+      }),
+  );
 
 /**
  * Base64文字列を効率的にUint8Arrayに変換する

--- a/src/utils/metadataManager.ts
+++ b/src/utils/metadataManager.ts
@@ -126,8 +126,9 @@ const removeTagsFromExifObj = (
   };
 
   // GPS関連のタグは piexif.GPSIFD の定義（全 GPS タグ名 → タグ ID）を参照して削除する
-  // （個別マッピングだと GPSLatitudeRef / GPSLongitudeRef 等の Ref 系タグが漏れるため）
-  const gpsTagMapping = piexif.GPSIFD as unknown as Record<string, number>;
+  // （個別マッピングだと GPSLatitudeRef / GPSLongitudeRef 等の Ref 系タグが漏れるため）。
+  // GPSIFD は索引シグネチャ（src/types/piexifjs.d.ts）でタグ名引きを許可済みのため二重キャスト不要
+  const gpsTagMapping = piexif.GPSIFD;
 
   for (const tagName of tagsToRemove) {
     // GPS全体を削除する場合


### PR DESCRIPTION
## Summary

#119 のチェックリスト5項目をすべて実装しました。挙動は完全に維持しています。

## Changes

- **`src/app/convert/page.tsx`** — `handleFilesSelected` / `handleClearFiles` / `handleSettingsChange` を `useCallback` 化。deps は Biome の `useExhaustiveDependencies` で機械検証済み。
- **`src/app/metadata/page.tsx`** — `gpsModeOptions` を `useMemo`（deps `[t]`）。`handleFilesSelected` と cleanup effect の `imageUrls` 連鎖は `imageUrlsRef` パターンで解消し、cleanup はアンマウント時のみに。naive な `deps []` だと初期の空 Map を閉じ込めてアンマウント時に revoke 漏れするため、ref 同期方式を採用しました。置換時の revoke は既存の書き込み側 2 箇所が担うため、二重 revoke だけが消えます。
- **`src/utils/imageUtils.ts` / `src/utils/imageConverter.ts`** — FileReader の `as string` を `fileToDataUrl` 経由に統一し、キャストを1箇所に集約。
- **`src/types/piexifjs.d.ts` / `src/utils/metadataManager.ts`** — `GPSIFD` にインデックスシグネチャを追加し、二重キャストを解消。
- **`src/app/crop/page.tsx`** — 同じ ref パターンで二重 revoke をアンマウント時のみに。

## Testing

Biome clean / `tsc --noEmit` clean / vitest **496 passed** / `next build` 成功。

## Follow-ups / Known Limitations

`imageConverter.convertImage` は日本語エラーメッセージ（「ファイルの読み込みに失敗しました」）を維持するため共通ヘルパーへは寄せず、2→1 箇所への集約に留めました。メッセージを揃えてよければ完全統一の follow-up も可能です。

スコープ外に残した「ほか」: `imageCropper.ts:35` の類似 reader は reject 値が異なるため、統一すると挙動が変わるので見送りました。`imageEditor.ts:198` は挙動同一で後日統一可能です。

Fixes #119

## Footer

Generated by Claude Opus 4.8 (1M context) (brief, implementation, review)